### PR TITLE
Add ability to redeploy capella cluster

### DIFF
--- a/cmd/tools-capella-redeploy.go
+++ b/cmd/tools-capella-redeploy.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var capellaRedeployCmd = &cobra.Command{
+	Use:   "capella-redeploy [flags] <cluster>",
+	Short: "Redeploy the capella cluster",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+
+		var err = deployer.RedeployCluster(
+			ctx,
+			cluster.GetID())
+		if err != nil {
+			logger.Fatal("failed to redeploy capella cluster", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	toolsCmd.AddCommand(capellaRedeployCmd)
+}

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -726,3 +726,7 @@ func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeID strin
 func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID string) error {
 	return errors.New("caodeploy does not support node pausing")
 }
+
+func (d *Deployer) RedeployCluster(ctx context.Context, clusterID string) error {
+	return errors.New("caodeploy does not support redeploy cluster")
+}

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -111,4 +111,5 @@ type Deployer interface {
 	SearchImages(ctx context.Context, version string) ([]Image, error)
 	PauseNode(ctx context.Context, clusterID string, nodeID string) error
 	UnpauseNode(ctx context.Context, clusterID string, nodeID string) error
+	RedeployCluster(ctx context.Context, clusterID string) error
 }

--- a/deployment/dockerdeploy/deployer.go
+++ b/deployment/dockerdeploy/deployer.go
@@ -1471,3 +1471,7 @@ func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID str
 
 	return nil
 }
+
+func (d *Deployer) RedeployCluster(ctx context.Context, clusterID string) error {
+	return errors.New("docker deploy does not support redeploy cluster")
+}

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -204,3 +204,7 @@ func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID str
 func (d *Deployer) LoadSampleBucket(ctx context.Context, clusterID string, bucketName string) error {
 	return errors.New("localdeploy does not support loading sample buckets")
 }
+
+func (d *Deployer) RedeployCluster(ctx context.Context, clusterID string) error {
+	return errors.New("localdeploy does not support redeploy cluster")
+}

--- a/utils/capellacontrol/controller.go
+++ b/utils/capellacontrol/controller.go
@@ -1286,3 +1286,14 @@ func (c *Controller) DownloadServerLogs(
 
 	return &DownloadServerLogsResponse{DownloadServerLogsStatuses: resp}, nil
 }
+
+func (c *Controller) RedeployCluster(
+	ctx context.Context,
+	clusterID string,
+	internalSupportToken string,
+) error {
+	path := fmt.Sprintf("/internal/support/clusters/%s/deploy", clusterID)
+	err := c.doTokenRequest(ctx, "POST", path, internalSupportToken, nil, nil)
+
+	return err
+}


### PR DESCRIPTION
Add ability to redeploy capella cluster

        1. add a sub command in cbidino tools
        2. ./cbdinocluster tools capella-redeploy <clusterId> 
        3. Run capella internal support redeploy cluster api