### PR TITLE
Print firewall notice if colima network cannot be detected

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -226,6 +226,13 @@ var initCmd = &cobra.Command{
 				return ""
 			}
 
+			if instance.Address == "" {
+				fmt.Println(`Failed to detect colima address with 'colima ls'.
+* make sure colima started with '--network-address'
+* try to disable firewall at 'System Settings' -> Network -> Firewall.`)
+				return ""
+			}
+
 			return instance.Address
 		}
 


### PR DESCRIPTION
This is how it would look like on recent OSx with enabled firewall:

```
-- Docker Configuration
Would you like to configure Docker Deployments? [Y/n]:
Checking for Colima installation at `/Users/user/.colima/default/docker.sock`... found.
Checking for Docker installation at `/var/run/docker.sock`... not found.
What docker host should we use? [unix:///Users/user/.colima/default/docker.sock]:
Pinging the docker host to confirm it works...
Success!
Listing docker networks:
  none
  bridge
  host
This appears to be colima, attempting to identify network information.
Attempting to fetch colima instance data.
Failed to detect colima address with 'colima ls'.
* make sure colima started with '--network-address'
* try to disable firewall at 'System Settings' -> Network -> Firewall.
Identified colima address of ``
Network identification failed, cannot auto-create dinonet network...What docker network should we use? [dinonet]:
```