### PR TITLE
ING-1051: Wait for data API to be enabled

### DIFF
--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2102,9 +2102,18 @@ func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
 	cloudProjectID := clusterInfo.Cluster.Project.Id
 	cloudClusterID := clusterInfo.Cluster.Id
 
+	d.logger.Debug("enabling data API")
+
 	err = d.client.EnableDataApi(ctx, d.tenantID, cloudProjectID, cloudClusterID)
 	if err != nil {
 		return errors.Wrap(err, "failed to enable Data API")
+	}
+
+	d.logger.Debug("waiting for Data API to enable")
+
+	err = d.mgr.WaitForDataApiEnabled(ctx, d.tenantID, cloudClusterID)
+	if err != nil {
+		return errors.Wrap(err, "failed to wait for Data API enablement")
 	}
 
 	return nil

--- a/utils/capellacontrol/controller.go
+++ b/utils/capellacontrol/controller.go
@@ -517,6 +517,7 @@ type ClusterInfo struct {
 	CreatedAt        time.Time           `json:"createdAt"`
 	CreatedBy        string              `json:"createdBy"`
 	CreatedByUserID  string              `json:"createdByUserID"`
+	DataApiState     string              `json:"dataApiState"`
 	Description      string              `json:"description"`
 	HasOnOffSchedule bool                `json:"hasOnOffSchedule"`
 	Id               string              `json:"id"`

--- a/utils/capellacontrol/manager.go
+++ b/utils/capellacontrol/manager.go
@@ -240,3 +240,46 @@ func (m *Manager) WaitForServerLogsCollected(
 		return perNode, nil
 	}
 }
+
+func (m *Manager) WaitForDataApiEnabled(
+	ctx context.Context,
+	tenantID, clusterID string) error {
+	desiredState := "enabled"
+
+	for {
+		dataApiState := ""
+
+		clusters, err := m.Client.ListAllClusters(ctx, tenantID, &PaginatedRequest{
+			Page:          1,
+			PerPage:       100,
+			SortBy:        "name",
+			SortDirection: "asc",
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to list clusters")
+		}
+
+		for _, cluster := range clusters.Data {
+			if cluster.Data.Id == clusterID {
+				dataApiState = cluster.Data.DataApiState
+			}
+		}
+
+		if dataApiState == "" {
+			return fmt.Errorf("cluster disappeared while waiting for data API to be enabled")
+		}
+
+		m.Logger.Info("waiting for data api state...",
+			zap.String("current", dataApiState),
+			zap.String("desired", desiredState))
+
+		if dataApiState != desiredState {
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		break
+	}
+
+	return nil
+}


### PR DESCRIPTION
When we enable Data API through cbdinocluster it would be useful if the command waited until Data API finished enabling, especially in the FIT-SIT use case where we need Data API to finish enabling before we can continue with the tests.