### PR TITLE
ING-1059: Return Data API hostname from enable command

### DIFF
--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -749,6 +749,6 @@ func (d *Deployer) UpgradeCluster(ctx context.Context, clusterID string, Current
 	return errors.New("caodeploy does not support upgrade cluster command")
 }
 
-func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
-	return errors.New("caodeploy does not support enabling data api")
+func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) (string, error) {
+	return "", errors.New("caodeploy does not support enabling data api")
 }

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2154,10 +2154,10 @@ func (d *Deployer) DropLink(ctx context.Context, columnarID, linkName string) er
 	return d.mgr.Client.DoBasicColumnarQuery(ctx, columnarInfo.Columnar.TenantID, columnarInfo.Columnar.ProjectID, columnarInfo.Columnar.ID, req)
 }
 
-func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
+func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) (string, error) {
 	clusterInfo, err := d.getCluster(ctx, clusterID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cloudProjectID := clusterInfo.Cluster.Project.Id
@@ -2167,17 +2167,17 @@ func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
 
 	err = d.client.EnableDataApi(ctx, d.tenantID, cloudProjectID, cloudClusterID)
 	if err != nil {
-		return errors.Wrap(err, "failed to enable Data API")
+		return "", errors.Wrap(err, "failed to enable Data API")
 	}
 
 	d.logger.Debug("waiting for Data API to enable")
 
-	err = d.mgr.WaitForDataApiEnabled(ctx, d.tenantID, cloudClusterID)
+	hostname, err := d.mgr.WaitForDataApiEnabled(ctx, d.tenantID, cloudClusterID)
 	if err != nil {
-		return errors.Wrap(err, "failed to wait for Data API enablement")
+		return "", errors.Wrap(err, "failed to wait for Data API enablement")
 	}
 
-	return nil
+	return hostname, nil
 }
 
 func (d *Deployer) GetGatewayCertificate(ctx context.Context, clusterID string) (string, error) {

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -126,5 +126,5 @@ type Deployer interface {
 	CreateCapellaLink(ctx context.Context, columnarID, linkName, clusterId, directID string) error
 	CreateS3Link(ctx context.Context, columnarID, linkName, region, endpoint, accessKey, secretKey string) error
 	DropLink(ctx context.Context, columnarID, linkName string) error
-	EnableDataApi(ctx context.Context, clusterID string) error
+	EnableDataApi(ctx context.Context, clusterID string) (string, error)
 }

--- a/deployment/dockerdeploy/deployer.go
+++ b/deployment/dockerdeploy/deployer.go
@@ -1601,6 +1601,6 @@ func (d *Deployer) UpgradeCluster(ctx context.Context, clusterID string, Current
 	return errors.New("docker deploy does not support upgrade cluster command")
 }
 
-func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
-	return errors.New("docker deploy does not support enabling data api")
+func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) (string, error) {
+	return "", errors.New("docker deploy does not support enabling data api")
 }

--- a/utils/capellacontrol/controller.go
+++ b/utils/capellacontrol/controller.go
@@ -518,6 +518,7 @@ type ClusterInfo struct {
 	CreatedBy        string              `json:"createdBy"`
 	CreatedByUserID  string              `json:"createdByUserID"`
 	DataApiState     string              `json:"dataApiState"`
+	DataApiHostname  string              `json:"dataApiHostname"`
 	Description      string              `json:"description"`
 	HasOnOffSchedule bool                `json:"hasOnOffSchedule"`
 	Id               string              `json:"id"`

--- a/utils/capellacontrol/manager.go
+++ b/utils/capellacontrol/manager.go
@@ -264,8 +264,9 @@ func (m *Manager) WaitForServerLogsCollected(
 
 func (m *Manager) WaitForDataApiEnabled(
 	ctx context.Context,
-	tenantID, clusterID string) error {
+	tenantID, clusterID string) (string, error) {
 	desiredState := "enabled"
+	dataApiHostname := ""
 
 	for {
 		dataApiState := ""
@@ -277,17 +278,18 @@ func (m *Manager) WaitForDataApiEnabled(
 			SortDirection: "asc",
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to list clusters")
+			return "", errors.Wrap(err, "failed to list clusters")
 		}
 
 		for _, cluster := range clusters.Data {
 			if cluster.Data.Id == clusterID {
 				dataApiState = cluster.Data.DataApiState
+				dataApiHostname = cluster.Data.DataApiHostname
 			}
 		}
 
 		if dataApiState == "" {
-			return fmt.Errorf("cluster disappeared while waiting for data API to be enabled")
+			return "", fmt.Errorf("cluster disappeared while waiting for data API to be enabled")
 		}
 
 		m.Logger.Info("waiting for data api state...",
@@ -302,5 +304,5 @@ func (m *Manager) WaitForDataApiEnabled(
 		break
 	}
 
-	return nil
+	return dataApiHostname, nil
 }


### PR DESCRIPTION
It would be useful if the `enable-dapi` command returned the Data API hostname, similarly to how cbd allocate returns the cluster ID. 