### PR TITLE
Set CGO_ENABLED to zero during binary build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Build Binary
-        run: GOOS=${{ matrix.platform }} GOARCH=${{ matrix.arch }} go build -o cbdinocluster-${{ matrix.platform }}-${{ matrix.arch }} -ldflags="-X github.com/couchbaselabs/cbdinocluster/contrib/buildversion.MainPkgVersion=${{ github.ref_name }}"
+        run: GOOS=${{ matrix.platform }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o cbdinocluster-${{ matrix.platform }}-${{ matrix.arch }} -ldflags="-X github.com/couchbaselabs/cbdinocluster/contrib/buildversion.MainPkgVersion=${{ github.ref_name }}"
       - uses: actions/upload-artifact@v4
         with:
           name: cbdinocluster-${{ matrix.platform }}-${{ matrix.arch }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Build Binary
-        run: GOOS=${{ matrix.platform }} GOARCH=amd64 go build -o cbdinocluster-${{ matrix.platform }} -ldflags="-X github.com/couchbaselabs/cbdinocluster/contrib/buildversion.MainPkgVersion=${{ github.sha }}"
+        run: GOOS=${{ matrix.platform }} GOARCH=amd64 CGO_ENABLED=0 go build -o cbdinocluster-${{ matrix.platform }} -ldflags="-X github.com/couchbaselabs/cbdinocluster/contrib/buildversion.MainPkgVersion=${{ github.sha }}"
       - uses: actions/upload-artifact@v4
         with:
           name: cbdinocluster-${{ matrix.platform }}


### PR DESCRIPTION
We are facing failures while running cbdino v0.0.61 to deploy capella provisioned cluster. Below is the error:
```./cbdinocluster-linux-amd64: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./cbdinocluster-linux-amd64)```

And [this](https://github.com/golang/go/issues/58550) golang issue suggests to use `CGO_ENABLED=0` to fix this issue.