### PR TITLE
SDKQE-3597: Use 'default' profile when fetching colima instance data

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -211,7 +211,7 @@ var initCmd = &cobra.Command{
 
 		getColimaAddress := func() string {
 			fmt.Printf("Attempting to fetch colima instance data.\n")
-			out, err := exec.Command("colima", "ls", "-j").Output()
+			out, err := exec.Command("colima", "ls", "-j", "-p", "default").Output()
 			if err != nil {
 				fmt.Printf("failed to execute colima: %s", err)
 				return ""

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/mod v0.24.0
@@ -118,7 +119,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect


### PR DESCRIPTION
When cbdino creates dinonet, it attempts to fetch colima instance data with the `colima ls` command. When more than one profiles exist, the output of `colima ls -j` looks similar to this:
```
> colima ls -j
{"name":"default","status":"Running","arch":"aarch64","cpus":4,"memory":6442450944,"disk":107374182400,"address":"192.168.106.2","runtime":"docker+k3s"}
{"name":"second","status":"Running","arch":"aarch64","cpus":2,"memory":2147483648,"disk":64424509440,"runtime":"docker"}
```

Parsing this output fails (which means creating dinonet also fails) because we assume that the output is a single JSON object.

We can filter the output with the `-p default` flag to ensure we only get one JSON object for the default profile.