### PR TITLE
SDKQE-3627: Load balance analytics to default HTTP/S ports

### DIFF
--- a/deployment/dockerdeploy/controller.go
+++ b/deployment/dockerdeploy/controller.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -439,46 +438,50 @@ func (c *Controller) UpdateNginxCertificates(ctx context.Context, containerID st
 	return nil
 }
 
-func (c *Controller) UpdateNginxConfig(ctx context.Context, containerID string, addrs []string, enableSsl bool) error {
+func (c *Controller) UpdateNginxConfig(ctx context.Context, containerID string, addrs []string, enableSsl, isAnalytics bool) error {
 	c.Logger.Debug("writing nginx config", zap.String("container", containerID), zap.Any("addrs", addrs))
 
 	var nginxConf string
-	writeForwardedPort := func(portInt int, stickySession bool, withSsl bool) {
-		if len(addrs) > 0 {
-			port := strconv.Itoa(portInt)
-
-			nginxConf += "upstream backend" + port + " {\n"
-			if stickySession {
-				nginxConf += "    ip_hash;\n"
-			}
-			for _, addr := range addrs {
-				nginxConf += "    server " + addr + ":" + port + ";\n"
-			}
-			nginxConf += "}\n"
-			nginxConf += "server {\n"
-
-			if !withSsl {
-				nginxConf += "    listen " + port + ";\n"
-			} else {
-				nginxConf += "    listen " + port + " ssl;\n"
-
-				nginxConf += "    ssl_certificate /etc/nginx/ssl/cert.pem;\n"
-				nginxConf += "    ssl_certificate_key /etc/nginx/ssl/key.pem;"
-			}
-
-			nginxConf += "    location / {\n"
-			if !withSsl {
-				nginxConf += "        proxy_pass http://backend" + port + ";\n"
-			} else {
-				nginxConf += "        proxy_pass https://backend" + port + ";\n"
-			}
-			nginxConf += "        proxy_set_header Host $http_host;\n"
-			nginxConf += "        proxy_set_header X-Real-IP $remote_addr;\n"
-			nginxConf += "        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
-			nginxConf += "    }\n"
-			nginxConf += "}\n"
+	writePortMapping := func(listenPort, targetPort int, stickySession, withSsl bool) {
+		if len(addrs) == 0 {
+			return
 		}
+
+		upstreamName := fmt.Sprintf("backend%d", listenPort)
+		nginxConf += fmt.Sprintf("upstream %s {\n", upstreamName)
+		if stickySession {
+			nginxConf += "    ip_hash;\n"
+		}
+		for _, addr := range addrs {
+			nginxConf += fmt.Sprintf("    server %s:%d;\n", addr, targetPort)
+		}
+		nginxConf += "}\n"
+
+		nginxConf += "server {\n"
+		if withSsl {
+			nginxConf += fmt.Sprintf("    listen %d ssl;\n", listenPort)
+			nginxConf += "    ssl_certificate /etc/nginx/ssl/cert.pem;\n"
+			nginxConf += "    ssl_certificate_key /etc/nginx/ssl/key.pem;\n"
+		} else {
+			nginxConf += fmt.Sprintf("    listen %d;\n", listenPort)
+		}
+
+		nginxConf += "    location / {\n"
+		protocol := "http"
+		if withSsl {
+			protocol = "https"
+		}
+		nginxConf += fmt.Sprintf("        proxy_pass %s://%s;\n", protocol, upstreamName)
+		nginxConf += "        proxy_set_header Host $http_host;\n"
+		nginxConf += "        proxy_set_header X-Real-IP $remote_addr;\n"
+		nginxConf += "        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
+		nginxConf += "    }\n"
+		nginxConf += "}\n"
 	}
+	writeForwardedPort := func(portInt int, stickySession bool, withSsl bool) {
+		writePortMapping(portInt, portInt, stickySession, withSsl)
+	}
+
 	writeForwardedPort(8091, true, false)
 	writeForwardedPort(8092, false, false)
 	writeForwardedPort(8093, false, false)
@@ -486,6 +489,11 @@ func (c *Controller) UpdateNginxConfig(ctx context.Context, containerID string, 
 	writeForwardedPort(8095, false, false)
 	writeForwardedPort(8096, false, false)
 	writeForwardedPort(8097, false, false)
+
+	if isAnalytics {
+		writePortMapping(80, 8095, false, false)
+	}
+
 	if enableSsl {
 		writeForwardedPort(18091, true, true)
 		writeForwardedPort(18092, false, true)
@@ -494,6 +502,9 @@ func (c *Controller) UpdateNginxConfig(ctx context.Context, containerID string, 
 		writeForwardedPort(18095, false, true)
 		writeForwardedPort(18096, false, true)
 		writeForwardedPort(18097, false, true)
+		if isAnalytics {
+			writePortMapping(443, 18095, false, true)
+		}
 	}
 
 	confBytes := []byte(nginxConf)

--- a/deployment/dockerdeploy/deployer.go
+++ b/deployment/dockerdeploy/deployer.go
@@ -699,15 +699,20 @@ func (d *Deployer) updateLoadBalancer(
 	enableSsl bool,
 ) error {
 	var addrs []string
+	isAnalytics := false
 	for _, node := range nodes {
 		if node.Type != "server-node" && node.Type != "columnar-node" {
 			continue
 		}
 
+		if node.Type == "columnar-node" {
+			isAnalytics = true
+		}
+
 		addrs = append(addrs, node.IPAddress)
 	}
 
-	return d.controller.UpdateNginxConfig(ctx, loadBalancerContainerId, addrs, enableSsl)
+	return d.controller.UpdateNginxConfig(ctx, loadBalancerContainerId, addrs, enableSsl, isAnalytics)
 }
 
 func (d *Deployer) updateDnsRecords(


### PR DESCRIPTION
Since the SDKs are expected to connect to the default HTTP/S ports (80/443) for Enterprise Analytics, we should add these rules to the LB so that we can test the expected deployment/behaviour.