### PR TITLE
Added support for creating network partitions.

### DIFF
--- a/cmd/chaos-partitiontraffic.go
+++ b/cmd/chaos-partitiontraffic.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"slices"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var chaosPartitionTrafficCmd = &cobra.Command{
+	Use:   "partition-traffic <cluster-id> [<node-id-or-ip> ...]",
+	Short: "Partitions intra-node traffic of the cluster",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+
+		// parse any nodes the user has explicitly specified
+		var partitionNodeIds []string
+		for _, nodeArg := range args[1:] {
+			node := helper.IdentifyNode(ctx, cluster, nodeArg)
+			partitionNodeIds = append(partitionNodeIds, node.GetID())
+		}
+
+		if len(partitionNodeIds) == 0 {
+			logger.Info("no nodes specified, partitioning half nodes in the cluster")
+
+			allNodes := cluster.GetNodes()
+			allNodeIds := make([]string, 0, len(allNodes))
+			for _, node := range allNodes {
+				allNodeIds = append(allNodeIds, node.GetID())
+			}
+
+			// sort the node IDs to ensure consistent partitioning
+			slices.Sort(allNodeIds)
+
+			numPartitionNodes := len(allNodeIds) / 2
+			if numPartitionNodes == 0 {
+				logger.Fatal("not enough nodes in the cluster to partition traffic")
+			}
+
+			partitionNodeIds = allNodeIds[:numPartitionNodes]
+		}
+
+		err := deployer.PartitionNodeTraffic(ctx, cluster.GetID(), partitionNodeIds)
+		if err != nil {
+			logger.Fatal("failed to partition node traffic", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	chaosCmd.AddCommand(chaosPartitionTrafficCmd)
+}

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -707,6 +707,10 @@ func (d *Deployer) BlockNodeTraffic(ctx context.Context, clusterID string, nodeI
 	return errors.New("caodeploy does not support traffic control")
 }
 
+func (d *Deployer) PartitionNodeTraffic(ctx context.Context, clusterID string, nodeIDs []string) error {
+	return errors.New("caodeploy does not support traffic control")
+}
+
 func (d *Deployer) AllowNodeTraffic(ctx context.Context, clusterID string, nodeID string) error {
 	return errors.New("caodeploy does not support traffic control")
 }

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2404,6 +2404,10 @@ func (d *Deployer) AllowNodeTraffic(ctx context.Context, clusterID string, nodeI
 	return errors.New("clouddeploy does not support traffic control")
 }
 
+func (d *Deployer) PartitionNodeTraffic(ctx context.Context, clusterID string, nodeIDs []string) error {
+	return errors.New("clouddeploy does not support traffic control")
+}
+
 func (d *Deployer) ListImages(ctx context.Context) ([]deployment.Image, error) {
 	return nil, errors.New("clouddeploy does not support image listing")
 }

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -120,6 +120,7 @@ type Deployer interface {
 	DeleteCollection(ctx context.Context, clusterID string, bucketName, scopeName, collectionName string) error
 	BlockNodeTraffic(ctx context.Context, clusterID string, nodeID string, blockType BlockNodeTrafficType) error
 	AllowNodeTraffic(ctx context.Context, clusterID string, nodeID string) error
+	PartitionNodeTraffic(ctx context.Context, clusterID string, nodeIDs []string) error
 	CollectLogs(ctx context.Context, clusterID string, destPath string) ([]string, error)
 	ListImages(ctx context.Context) ([]Image, error)
 	SearchImages(ctx context.Context, version string) ([]Image, error)

--- a/deployment/dockerdeploy/clusterinfo.go
+++ b/deployment/dockerdeploy/clusterinfo.go
@@ -12,7 +12,6 @@ type ClusterNodeInfo struct {
 	Name       string
 	ResourceID string
 	IPAddress  string
-	DnsName    string
 }
 
 var _ (deployment.ClusterNodeInfo) = (*ClusterNodeInfo)(nil)
@@ -30,24 +29,14 @@ type ClusterInfo struct {
 	Owner     string
 	Purpose   string
 	Expiry    time.Time
-	Nodes     []*ClusterNodeInfo
-	DnsName   string
-
-	// TODO(brett19): this should not be here
-	LoadBalancerIPAddress string
+	Nodes     []deployment.ClusterNodeInfo
 }
 
 var _ (deployment.ClusterInfo) = (*ClusterInfo)(nil)
 
-func (i ClusterInfo) GetID() string                   { return i.ClusterID }
-func (i ClusterInfo) GetType() deployment.ClusterType { return i.Type }
-func (i ClusterInfo) GetPurpose() string              { return i.Purpose }
-func (i ClusterInfo) GetExpiry() time.Time            { return i.Expiry }
-func (i ClusterInfo) GetState() string                { return "ready" }
-func (i ClusterInfo) GetNodes() []deployment.ClusterNodeInfo {
-	var nodes []deployment.ClusterNodeInfo
-	for _, node := range i.Nodes {
-		nodes = append(nodes, node)
-	}
-	return nodes
-}
+func (i ClusterInfo) GetID() string                          { return i.ClusterID }
+func (i ClusterInfo) GetType() deployment.ClusterType        { return i.Type }
+func (i ClusterInfo) GetPurpose() string                     { return i.Purpose }
+func (i ClusterInfo) GetExpiry() time.Time                   { return i.Expiry }
+func (i ClusterInfo) GetState() string                       { return "ready" }
+func (i ClusterInfo) GetNodes() []deployment.ClusterNodeInfo { return i.Nodes }

--- a/deployment/dockerdeploy/deployer_certs.go
+++ b/deployment/dockerdeploy/deployer_certs.go
@@ -1,0 +1,96 @@
+package dockerdeploy
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/couchbaselabs/cbdinocluster/utils/clustercontrol"
+	"github.com/couchbaselabs/cbdinocluster/utils/dinocerts"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func (d *Deployer) getClusterDinoCert(clusterID string) (*dinocerts.CertAuthority, []byte, error) {
+	rootCa, err := dinocerts.GetRootCertAuthority()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get root dino ca")
+	}
+
+	fetchedClusterCa, err := rootCa.MakeIntermediaryCA("cluster-" + clusterID[:8])
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get cluster dino ca")
+	}
+
+	return fetchedClusterCa, rootCa.CertPem, nil
+}
+
+func (d *Deployer) setupNodeCertificates(
+	ctx context.Context,
+	node *ContainerInfo,
+	clusterCa *dinocerts.CertAuthority,
+	rootCaPem []byte,
+) error {
+	nodeIP := net.ParseIP(node.IPAddress)
+
+	var dnsNames []string
+	if node.DnsName != "" {
+		dnsNames = append(dnsNames, node.DnsName)
+	}
+	if node.DnsSuffix != "" {
+		dnsNames = append(dnsNames, node.DnsSuffix)
+	}
+
+	d.logger.Debug("generating node dinocert certificate",
+		zap.String("node", node.NodeID),
+		zap.Any("IP", nodeIP),
+		zap.Any("dnsNames", dnsNames))
+
+	certPem, keyPem, err := clusterCa.MakeServerCertificate("node-"+node.NodeID[:8], []net.IP{nodeIP}, dnsNames)
+	if err != nil {
+		return errors.Wrap(err, "failed to create server certificate")
+	}
+
+	d.logger.Debug("uploading dinocert certificates",
+		zap.String("node", node.NodeID))
+
+	var chainPem []byte
+	chainPem = append(chainPem, certPem...)
+	chainPem = append(chainPem, clusterCa.CertPem...)
+	err = d.controller.UploadCertificates(ctx, node.ContainerID, chainPem, keyPem, [][]byte{rootCaPem})
+	if err != nil {
+		return errors.Wrap(err, "failed to upload certificates")
+	}
+
+	nodeCtrl := clustercontrol.NodeManager{
+		Endpoint: fmt.Sprintf("http://%s:8091", node.IPAddress),
+	}
+
+	d.logger.Debug("refreshing trusted CAs for node",
+		zap.String("node", node.NodeID))
+
+	err = nodeCtrl.Controller().LoadTrustedCAs(ctx, &clustercontrol.LoadTrustedCAsOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to load trusted CAs")
+	}
+
+	d.logger.Debug("refreshing certificate for node",
+		zap.String("node", node.NodeID))
+
+	err = nodeCtrl.Controller().ReloadCertificate(ctx, &clustercontrol.ReloadCertificateOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to refresh certificates")
+	}
+
+	d.logger.Debug("removing default self-signed certificate for node",
+		zap.String("node", node.NodeID))
+
+	err = nodeCtrl.Controller().DeleteTrustedCA(ctx, &clustercontrol.DeleteTrustedCAOptions{
+		ID: 0,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to delete default certificate")
+	}
+
+	return nil
+}

--- a/deployment/dockerdeploy/deployer_clusterinfo.go
+++ b/deployment/dockerdeploy/deployer_clusterinfo.go
@@ -1,0 +1,223 @@
+package dockerdeploy
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/couchbaselabs/cbdinocluster/clusterdef"
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/couchbaselabs/cbdinocluster/utils/clustercontrol"
+	"github.com/pkg/errors"
+)
+
+type clusterInfo struct {
+	ClusterID      string
+	Type           deployment.ClusterType
+	Creator        string
+	Owner          string
+	Purpose        string
+	Expiry         time.Time
+	DnsName        string
+	UsingDinoCerts bool
+	Nodes          []*nodeInfo
+}
+
+func (c clusterInfo) IsColumnar() bool {
+	return c.Type == deployment.ClusterTypeColumnar
+}
+
+func (c clusterInfo) LoadBalancerIPAddress() string {
+	for _, node := range c.Nodes {
+		if node.IsLoadBalancerNode() {
+			return node.IPAddress
+		}
+	}
+	return ""
+}
+
+type nodeInfo struct {
+	NodeID               string
+	Type                 string
+	Name                 string
+	ContainerID          string
+	IPAddress            string
+	DnsName              string
+	InitialServerVersion string
+}
+
+func (i nodeInfo) IsClusterNode() bool {
+	return i.Type == "server-node" || i.Type == "columnar-node"
+}
+
+func (i nodeInfo) IsColumnarNode() bool {
+	return i.Type == "columnar-node"
+}
+
+func (i nodeInfo) IsLoadBalancerNode() bool {
+	return i.Type == "nginx"
+}
+
+func (d *Deployer) listClusters(ctx context.Context) ([]*clusterInfo, error) {
+	nodes, err := d.controller.ListNodes(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+
+	// sort the nodes by their name for nicer printing later
+	slices.SortFunc(nodes, func(a *ContainerInfo, b *ContainerInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	var clusters []*clusterInfo
+	getCluster := func(clusterID string) *clusterInfo {
+		for _, cluster := range clusters {
+			if cluster.ClusterID == clusterID {
+				return cluster
+			}
+		}
+		cluster := &clusterInfo{
+			ClusterID: clusterID,
+			Type:      deployment.ClusterTypeServer,
+		}
+		clusters = append(clusters, cluster)
+		return cluster
+	}
+
+	for _, node := range nodes {
+		cluster := getCluster(node.ClusterID)
+
+		nodeInfo := &nodeInfo{
+			NodeID:               node.NodeID,
+			Type:                 node.Type,
+			Name:                 node.Name,
+			ContainerID:          node.ContainerID,
+			IPAddress:            node.IPAddress,
+			DnsName:              node.DnsName,
+			InitialServerVersion: node.InitialServerVersion,
+		}
+		cluster.Nodes = append(cluster.Nodes, nodeInfo)
+
+		if nodeInfo.IsClusterNode() {
+			cluster.Creator = node.Creator
+			cluster.Owner = node.Owner
+			cluster.Purpose = node.Purpose
+			if !node.Expiry.IsZero() && node.Expiry.After(cluster.Expiry) {
+				cluster.Expiry = node.Expiry
+			}
+			cluster.DnsName = node.DnsSuffix
+			cluster.UsingDinoCerts = node.UsingDinoCerts
+		}
+
+		// if any nodes are columnar nodes, the cluster is a columnar cluster
+		if nodeInfo.IsColumnarNode() {
+			cluster.Type = deployment.ClusterTypeColumnar
+		}
+	}
+
+	return clusters, nil
+}
+
+func (d *Deployer) getCluster(ctx context.Context, clusterID string) (*clusterInfo, error) {
+	clusters, err := d.listClusters(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list nodes")
+	}
+
+	var thisCluster *clusterInfo
+	for _, cluster := range clusters {
+		if cluster.ClusterID == clusterID {
+			thisCluster = cluster
+		}
+	}
+	if thisCluster == nil {
+		return nil, errors.New("failed to find cluster")
+	}
+
+	return thisCluster, nil
+}
+
+type clusterInfoEx struct {
+	clusterInfo
+
+	NodesEx []*nodeInfoEx
+}
+
+type nodeInfoEx struct {
+	nodeInfo
+
+	OTPNode  string
+	Services []clusterdef.Service
+}
+
+func (d *Deployer) getNodeInfoEx(ctx context.Context, nodeInfo *nodeInfo) (*nodeInfoEx, error) {
+	nodeEx := &nodeInfoEx{
+		nodeInfo: *nodeInfo,
+	}
+
+	if nodeInfo.IsClusterNode() {
+		nodeCtrl := clustercontrol.NodeManager{
+			Endpoint: fmt.Sprintf("http://%s:8091", nodeInfo.IPAddress),
+		}
+		thisNodeInfo, err := nodeCtrl.Controller().GetLocalInfo(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list a nodes services")
+		}
+
+		services, err := clusterdef.NsServicesToServices(thisNodeInfo.Services)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate services list")
+		}
+
+		nodeEx.OTPNode = thisNodeInfo.OTPNode
+		nodeEx.Services = services
+	}
+
+	return nodeEx, nil
+}
+
+func (d *Deployer) getClusterInfoEx(ctx context.Context, clusterInfo *clusterInfo) (*clusterInfoEx, error) {
+	cluster := &clusterInfoEx{
+		clusterInfo: *clusterInfo,
+	}
+
+	for _, node := range cluster.Nodes {
+		nodeEx, err := d.getNodeInfoEx(ctx, node)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get extended node info")
+		}
+
+		cluster.NodesEx = append(cluster.NodesEx, nodeEx)
+	}
+
+	return cluster, nil
+}
+
+func (d *Deployer) nodeInfoFromNode(node *nodeInfo) deployment.ClusterNodeInfo {
+	return &ClusterNodeInfo{
+		NodeID:     node.NodeID,
+		IsNode:     node.IsClusterNode(),
+		Name:       node.Name,
+		ResourceID: node.ContainerID[0:8] + "...",
+		IPAddress:  node.IPAddress,
+	}
+}
+
+func (d *Deployer) clusterInfoFromCluster(cluster *clusterInfo) deployment.ClusterInfo {
+	var nodes []deployment.ClusterNodeInfo
+	for _, node := range cluster.Nodes {
+		nodes = append(nodes, d.nodeInfoFromNode(node))
+	}
+
+	return &ClusterInfo{
+		ClusterID: cluster.ClusterID,
+		Type:      cluster.Type,
+		Creator:   cluster.Creator,
+		Owner:     cluster.Owner,
+		Purpose:   cluster.Purpose,
+		Expiry:    cluster.Expiry,
+		Nodes:     nodes,
+	}
+}

--- a/deployment/dockerdeploy/deployer_dns.go
+++ b/deployment/dockerdeploy/deployer_dns.go
@@ -1,0 +1,121 @@
+package dockerdeploy
+
+import (
+	"context"
+	"slices"
+
+	"go.uber.org/zap"
+)
+
+func (d *Deployer) updateDnsRecords(
+	ctx context.Context,
+	dnsName string,
+	nodes []*nodeInfo,
+	isColumnar bool,
+	loadBalancerIp string,
+	isNewCluster bool,
+) error {
+	var records []DnsRecord
+
+	var allNodeAs []string
+	var allNodeSrvs []string
+	var allNodeSecSrvs []string
+
+	for _, node := range nodes {
+		if node.Type != "server-node" && node.Type != "columnar-node" {
+			continue
+		}
+
+		/* don't spam the dns names for now...
+		records = append(records, DnsRecord{
+			RecordType: "A",
+			Name:       node.DnsName,
+			Addrs:      []string{node.IPAddress},
+		})
+		*/
+
+		allNodeAs = append(allNodeAs, node.IPAddress)
+		allNodeSrvs = append(allNodeSrvs, "0 0 11210 "+node.IPAddress)
+		allNodeSecSrvs = append(allNodeSecSrvs, "0 0 11207 "+node.IPAddress)
+	}
+
+	if !isColumnar || loadBalancerIp == "" {
+		records = append(records, DnsRecord{
+			RecordType: "A",
+			Name:       dnsName,
+			Addrs:      allNodeAs,
+		})
+	} else {
+		// no need to update the A record for the load balancer on every modify
+		if isNewCluster {
+			records = append(records, DnsRecord{
+				RecordType: "A",
+				Name:       dnsName,
+				Addrs:      []string{loadBalancerIp},
+			})
+		}
+	}
+
+	if !isColumnar {
+		records = append(records, DnsRecord{
+			RecordType: "SRV",
+			Name:       "_couchbase._tcp.srv." + dnsName,
+			Addrs:      allNodeSrvs,
+		})
+
+		records = append(records, DnsRecord{
+			RecordType: "SRV",
+			Name:       "_couchbases._tcp.srv." + dnsName,
+			Addrs:      allNodeSecSrvs,
+		})
+	}
+
+	d.logger.Info("updating dns records", zap.Any("records", records))
+
+	noWait := isNewCluster
+	err := d.dnsProvider.UpdateRecords(ctx, records, noWait, false)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Info("records created")
+	return nil
+}
+
+func (d *Deployer) appendNodeDnsNames(dnsNames []string, node *ContainerInfo) []string {
+	if node.DnsName != "" {
+		if !slices.Contains(dnsNames, node.DnsName) {
+			dnsNames = append(dnsNames, node.DnsName)
+		}
+	}
+	if node.DnsSuffix != "" {
+		couchbaseRec := "_couchbase._tcp.srv." + node.DnsSuffix
+		couchbasesRec := "_couchbases._tcp.srv." + node.DnsSuffix
+
+		if !slices.Contains(dnsNames, node.DnsSuffix) {
+			dnsNames = append(dnsNames, node.DnsSuffix)
+		}
+		if !slices.Contains(dnsNames, couchbaseRec) {
+			dnsNames = append(dnsNames, couchbaseRec)
+		}
+		if !slices.Contains(dnsNames, couchbasesRec) {
+			dnsNames = append(dnsNames, couchbasesRec)
+		}
+	}
+
+	return dnsNames
+}
+
+func (d *Deployer) removeDnsNames(ctx context.Context, dnsNames []string) {
+	if len(dnsNames) > 0 {
+		if d.dnsProvider == nil {
+			d.logger.Warn("could not remove associated dns names due to no dns configuration")
+		} else {
+			d.logger.Info("removing dns names", zap.Any("names", dnsNames))
+			err := d.dnsProvider.RemoveRecords(ctx, dnsNames, true, true)
+			if err != nil {
+				d.logger.Warn("failed to remove dns names", zap.Error(err))
+			}
+		}
+	}
+}

--- a/deployment/dockerdeploy/deployer_lb.go
+++ b/deployment/dockerdeploy/deployer_lb.go
@@ -1,0 +1,22 @@
+package dockerdeploy
+
+import "context"
+
+func (d *Deployer) updateLoadBalancer(
+	ctx context.Context,
+	loadBalancerContainerId string,
+	nodes []*nodeInfo,
+	isColumnar bool,
+	enableSsl bool,
+) error {
+	var addrs []string
+	for _, node := range nodes {
+		if !node.IsClusterNode() {
+			continue
+		}
+
+		addrs = append(addrs, node.IPAddress)
+	}
+
+	return d.controller.UpdateNginxConfig(ctx, loadBalancerContainerId, addrs, enableSsl, isColumnar)
+}

--- a/deployment/dockerdeploy/deployer_newaddremove.go
+++ b/deployment/dockerdeploy/deployer_newaddremove.go
@@ -1,0 +1,699 @@
+package dockerdeploy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/couchbaselabs/cbdinocluster/clusterdef"
+	"github.com/couchbaselabs/cbdinocluster/utils/clustercontrol"
+	"github.com/couchbaselabs/cbdinocluster/utils/dinocerts"
+	"github.com/couchbaselabs/cbdinocluster/utils/versionident"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
+)
+
+func (d *Deployer) getImagesForNodeGrps(ctx context.Context, nodeGrps []*clusterdef.NodeGroup, isColumnar bool) ([]*ImageRef, error) {
+	nodeGrpDefs := make([]*ImageDef, len(nodeGrps))
+	nodeGrpImages := make([]*ImageRef, len(nodeGrps))
+	for nodeGrpIdx, nodeGrp := range nodeGrps {
+		if nodeGrp.Docker.Image != "" {
+			foundImageRef, err := d.imageProvider.GetImageRaw(ctx, nodeGrp.Docker.Image)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get image for a node")
+			}
+
+			nodeGrpImages[nodeGrpIdx] = foundImageRef
+			continue
+		}
+
+		versionInfo, err := versionident.Identify(ctx, nodeGrp.Version)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to identify version")
+		}
+
+		imageDef := &ImageDef{
+			Version:             versionInfo.Version,
+			BuildNo:             versionInfo.BuildNo,
+			UseCommunityEdition: versionInfo.CommunityEdition,
+			UseServerless:       versionInfo.Serverless,
+			UseColumnar:         isColumnar,
+		}
+		nodeGrpDefs[nodeGrpIdx] = imageDef
+
+		var imageRef *ImageRef
+		for oNodeGrpIdx := 0; oNodeGrpIdx < nodeGrpIdx; oNodeGrpIdx++ {
+			if CompareImageDefs(nodeGrpDefs[oNodeGrpIdx], imageDef) == 0 {
+				imageRef = nodeGrpImages[oNodeGrpIdx]
+			}
+		}
+
+		if imageRef == nil {
+			foundImageRef, err := d.imageProvider.GetImage(ctx, imageDef)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get image for a node")
+			}
+
+			imageRef = foundImageRef
+		}
+
+		nodeGrpImages[nodeGrpIdx] = imageRef
+	}
+
+	return nodeGrpImages, nil
+}
+
+func (d *Deployer) newCluster(ctx context.Context, def *clusterdef.Cluster) (*clusterInfo, error) {
+	if def.Columnar {
+		for _, nodeGrp := range def.NodeGroups {
+			if len(nodeGrp.Services) != 0 {
+				return nil, errors.New("columnar clusters cannot specify services")
+			}
+
+			nodeGrp.Services = []clusterdef.Service{
+				clusterdef.KvService,
+				clusterdef.AnalyticsService,
+			}
+		}
+	}
+
+	clusterID := uuid.NewString()
+
+	useDns := def.Docker.EnableDNS
+	if useDns && d.dnsProvider == nil {
+		return nil, errors.New("cannot use dns, dns not configured")
+	}
+
+	var dnsName string
+	if useDns {
+		dnsHostname := d.dnsProvider.GetHostname()
+		dnsName = fmt.Sprintf("%s-%s.%s",
+			clusterID[:8],
+			time.Now().Format("20060102"),
+			dnsHostname)
+	}
+
+	var rootCaPem []byte
+	var clusterCa *dinocerts.CertAuthority
+	if def.Docker.UseDinoCerts {
+		var err error
+		clusterCa, rootCaPem, err = d.getClusterDinoCert(clusterID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get cluster dino ca")
+		}
+	}
+
+	if def.Columnar {
+		d.logger.Info("deploying mock s3 for blob storage")
+
+		d.logger.Debug("deploying s3mock container")
+
+		node, err := d.controller.DeployS3MockNode(ctx, clusterID, def.Expiry)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to deploy s3mock node")
+		}
+
+		d.logger.Debug("creating columnar bucket")
+
+		bucketName := "columnar"
+		req, err := http.NewRequest(
+			"PUT",
+			fmt.Sprintf("http://%s:9090/%s/", node.IPAddress, bucketName),
+			nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create columnar s3 bucket request")
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create columnar s3 bucket")
+		}
+		if resp.StatusCode != 200 {
+			return nil, fmt.Errorf("non-200 status code when creating columnar s3 bucket (code: %d)", resp.StatusCode)
+		}
+
+		d.logger.Info("s3 mock is ready")
+
+		def.Docker.Analytics.BlobStorage = clusterdef.AnalyticsBlobStorageSettings{
+			Region:         "local",
+			Bucket:         "columnar",
+			Scheme:         "s3",
+			Endpoint:       fmt.Sprintf("http://%s:9090", node.IPAddress),
+			AnonymousAuth:  true,
+			ForcePathStyle: true,
+		}
+	}
+
+	nginxContainerId := ""
+	nginxIpAddress := ""
+	if def.Docker.EnableLoadBalancer {
+		d.logger.Info("deploying nginx for load balancing")
+
+		node, err := d.controller.DeployNginxNode(ctx, clusterID, def.Expiry)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to deploy nginx node")
+		}
+
+		d.logger.Debug("nginx started", zap.String("ip", node.IPAddress))
+
+		if clusterCa != nil {
+			d.logger.Debug("uploading dinocert certificates to nginx",
+				zap.String("nginx", node.NodeID))
+
+			ip := net.ParseIP(node.IPAddress)
+
+			var dnsNames []string
+			if dnsName != "" {
+				dnsNames = append(dnsNames, dnsName)
+			}
+
+			certPem, keyPem, err := clusterCa.MakeServerCertificate("nginx-"+clusterID[:8], []net.IP{ip}, dnsNames)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create nginx certificate")
+			}
+
+			var chainPem []byte
+			chainPem = append(chainPem, certPem...)
+			chainPem = append(chainPem, clusterCa.CertPem...)
+			err = d.controller.UpdateNginxCertificates(ctx, node.ContainerID, chainPem, keyPem)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to upload nginx certificates")
+			}
+		}
+
+		nginxContainerId = node.ContainerID
+		nginxIpAddress = node.IPAddress
+	}
+
+	d.logger.Info("gathering node images")
+
+	nodeGrpImages, err := d.getImagesForNodeGrps(ctx, def.NodeGroups, def.Columnar)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch images")
+	}
+
+	d.logger.Info("deploying nodes")
+
+	nodes := make([]*ContainerInfo, 0)
+	leaveNodesAfterReturn := false
+	cleanupNodes := func() {
+		if !leaveNodesAfterReturn {
+			for _, node := range nodes {
+				if node != nil {
+					d.controller.RemoveNode(ctx, node.ContainerID)
+				}
+			}
+		}
+	}
+	defer cleanupNodes()
+
+	var nodeOpts []*DeployNodeOptions
+	var nodeNodeGrps []*clusterdef.NodeGroup
+	for nodeGrpIdx, nodeGrp := range def.NodeGroups {
+		// We grab the number of nodes to allocate and copy the group out
+		// for each individual node with a count of 1
+		numNodes := nodeGrp.Count
+		nodeGrp := to.Ptr(*nodeGrp)
+		nodeGrp.Count = 1
+
+		for grpNodeIdx := 0; grpNodeIdx < numNodes; grpNodeIdx++ {
+			d.logger.Info("deploying", zap.Any("nodeGrp", nodeGrp))
+
+			image := nodeGrpImages[nodeGrpIdx]
+
+			deployOpts := &DeployNodeOptions{
+				Purpose:            def.Purpose,
+				ClusterID:          clusterID,
+				Image:              image,
+				ImageServerVersion: nodeGrp.Version,
+				IsColumnar:         def.Columnar,
+				DnsSuffix:          dnsName,
+				Expiry:             def.Expiry,
+				EnvVars:            nodeGrp.Docker.EnvVars,
+				UseDinoCerts:       def.Docker.UseDinoCerts,
+			}
+
+			nodeOpts = append(nodeOpts, deployOpts)
+			nodeNodeGrps = append(nodeNodeGrps, nodeGrp)
+		}
+	}
+
+	waitCh := make(chan error)
+	for _, deployOpts := range nodeOpts {
+		go func(deployOpts *DeployNodeOptions) {
+			d.logger.Info("deploying node", zap.Any("deployOpts", deployOpts))
+
+			node, err := d.controller.DeployNode(ctx, deployOpts)
+			if err != nil {
+				waitCh <- errors.Wrap(err, "failed to deploy a node")
+				return
+			}
+
+			d.logger.Info("deployed node",
+				zap.String("address", node.IPAddress),
+				zap.String("id", node.NodeID),
+				zap.String("container", node.ContainerID))
+
+			nodes = append(nodes, node)
+			waitCh <- nil
+		}(deployOpts)
+	}
+	for range nodeOpts {
+		err := <-waitCh
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	d.logger.Info("nodes deployed", zap.String("cluster", clusterID))
+
+	// we cheat for now...
+	thisCluster, err := d.getCluster(ctx, clusterID)
+	if err != nil {
+		return nil, errors.New("failed to find new cluster after deployment")
+	}
+
+	leaveNodesAfterReturn = true
+
+	if clusterCa != nil {
+		d.logger.Info("setting up dinocert certificates", zap.String("cluster", clusterID))
+
+		for _, node := range nodes {
+			err := d.setupNodeCertificates(ctx, node, clusterCa, rootCaPem)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to setup node certificates")
+			}
+		}
+	}
+
+	if useDns {
+		// since this is a net-new domain name, no need to wait for dns propagation
+		err = d.updateDnsRecords(ctx, dnsName, thisCluster.Nodes, def.Columnar, nginxIpAddress, true)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to update dns records")
+		}
+	}
+
+	if nginxContainerId != "" {
+		useDinoCerts := false
+		if clusterCa != nil {
+			useDinoCerts = true
+		}
+
+		err = d.updateLoadBalancer(ctx, nginxContainerId, thisCluster.Nodes, def.Columnar, useDinoCerts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to update load balancer")
+		}
+	}
+
+	// we need to sort the nodes by server version so that the oldest server version
+	// is the first one initialized, otherwise in mixed-version clusters, we might
+	// end up initializing the higher version nodes first, disallowing older nodes
+	// from being initialized into the cluster (couchbase does not permit downgrades).
+	// We also sort by IP address next
+	slices.SortFunc(nodes, func(a, b *ContainerInfo) int {
+		res := semver.Compare("v"+a.InitialServerVersion, "v"+b.InitialServerVersion)
+		if res != 0 {
+			return res
+		}
+		return strings.Compare(a.IPAddress, b.IPAddress)
+	})
+	d.logger.Debug("reordered setup order", zap.Any("nodes", nodes))
+
+	var setupNodeOpts []*clustercontrol.SetupNewClusterNodeOptions
+	for nodeIdx, node := range nodes {
+		nodeGrp := nodeNodeGrps[nodeIdx]
+
+		services := nodeGrp.Services
+		if len(services) == 0 {
+			services = DEFAULT_SERVICES
+		}
+
+		nsServices, err := clusterdef.ServicesToNsServices(services)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate ns server services list")
+		}
+
+		setupNodeOpts = append(setupNodeOpts, &clustercontrol.SetupNewClusterNodeOptions{
+			Address:     node.IPAddress,
+			ServerGroup: nodeGrp.ServerGroup,
+			Services:    nsServices,
+		})
+	}
+
+	var clusterServices []clusterdef.Service
+	for _, node := range setupNodeOpts {
+		for _, serviceName := range node.Services {
+			service := clusterdef.Service(serviceName)
+			if !slices.Contains(clusterServices, service) {
+				clusterServices = append(clusterServices, service)
+			}
+		}
+	}
+
+	kvMemoryQuotaMB := 256
+	indexMemoryQuotaMB := 256
+	ftsMemoryQuotaMB := 256
+	cbasMemoryQuotaMB := 1024
+	eventingMemoryQuotaMB := 256
+	username := "Administrator"
+	password := "password"
+
+	hasKvService := slices.Contains(clusterServices, clusterdef.KvService)
+	hasIndexService := slices.Contains(clusterServices, clusterdef.IndexService)
+	hasFtsService := slices.Contains(clusterServices, clusterdef.SearchService)
+	hasAnalyticsService := slices.Contains(clusterServices, clusterdef.AnalyticsService)
+	hasEventingService := slices.Contains(clusterServices, clusterdef.EventingService)
+
+	if !hasKvService {
+		kvMemoryQuotaMB = 0
+	}
+	if !hasIndexService {
+		indexMemoryQuotaMB = 0
+	}
+	if !hasFtsService {
+		ftsMemoryQuotaMB = 0
+	}
+	if !hasAnalyticsService {
+		cbasMemoryQuotaMB = 0
+	}
+	if !hasEventingService {
+		eventingMemoryQuotaMB = 0
+	}
+
+	if def.Docker.KvMemoryMB > 0 {
+		kvMemoryQuotaMB = def.Docker.KvMemoryMB
+	}
+	if def.Docker.IndexMemoryMB > 0 {
+		indexMemoryQuotaMB = def.Docker.IndexMemoryMB
+	}
+	if def.Docker.FtsMemoryMB > 0 {
+		ftsMemoryQuotaMB = def.Docker.FtsMemoryMB
+	}
+	if def.Docker.CbasMemoryMB > 0 {
+		cbasMemoryQuotaMB = def.Docker.CbasMemoryMB
+	}
+	if def.Docker.EventingMemoryMB > 0 {
+		eventingMemoryQuotaMB = def.Docker.EventingMemoryMB
+	}
+	if def.Docker.Username != "" {
+		username = def.Docker.Username
+	}
+	if def.Docker.Password != "" {
+		password = def.Docker.Password
+	}
+
+	if kvMemoryQuotaMB < 256 && hasKvService {
+		d.logger.Warn("kv memory must be at least 256, adjusting it...")
+		kvMemoryQuotaMB = 256
+	}
+	if indexMemoryQuotaMB < 256 && hasIndexService {
+		d.logger.Warn("index memory must be at least 256, adjusting it...")
+		indexMemoryQuotaMB = 256
+	}
+	if ftsMemoryQuotaMB < 256 && hasFtsService {
+		d.logger.Warn("fts memory must be at least 256, adjusting it...")
+		ftsMemoryQuotaMB = 256
+	}
+	if cbasMemoryQuotaMB < 1024 && hasAnalyticsService {
+		d.logger.Warn("cbas memory must be at least 1024, adjusting it...")
+		cbasMemoryQuotaMB = 1024
+	}
+	if eventingMemoryQuotaMB < 256 && hasEventingService {
+		d.logger.Warn("eventing memory must be at least 256, adjusting it...")
+		eventingMemoryQuotaMB = 256
+	}
+
+	analyticsSettings := clustercontrol.AnalyticsSettings{
+		BlobStorageRegion:         def.Docker.Analytics.BlobStorage.Region,
+		BlobStoragePrefix:         def.Docker.Analytics.BlobStorage.Prefix,
+		BlobStorageBucket:         def.Docker.Analytics.BlobStorage.Bucket,
+		BlobStorageScheme:         def.Docker.Analytics.BlobStorage.Scheme,
+		BlobStorageEndpoint:       def.Docker.Analytics.BlobStorage.Endpoint,
+		BlobStorageAnonymousAuth:  def.Docker.Analytics.BlobStorage.AnonymousAuth,
+		BlobStorageForcePathStyle: def.Docker.Analytics.BlobStorage.ForcePathStyle,
+	}
+	d.logger.Debug("analytics configuration", zap.Any("settings", analyticsSettings))
+
+	setupOpts := &clustercontrol.SetupNewClusterOptions{
+		KvMemoryQuotaMB:       kvMemoryQuotaMB,
+		IndexMemoryQuotaMB:    indexMemoryQuotaMB,
+		FtsMemoryQuotaMB:      ftsMemoryQuotaMB,
+		CbasMemoryQuotaMB:     cbasMemoryQuotaMB,
+		EventingMemoryQuotaMB: eventingMemoryQuotaMB,
+		Username:              username,
+		Password:              password,
+		Nodes:                 setupNodeOpts,
+		AnalyticsSettings:     analyticsSettings,
+	}
+
+	clusterMgr := clustercontrol.ClusterManager{
+		Logger: d.logger,
+	}
+	err = clusterMgr.SetupNewCluster(ctx, setupOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to setup cluster")
+	}
+
+	leaveNodesAfterReturn = true
+	return thisCluster, nil
+}
+
+func (d *Deployer) addRemoveNodes(
+	ctx context.Context,
+	clusterInfo *clusterInfoEx,
+	nodesToAdd []*clusterdef.NodeGroup,
+	nodesToRemove []*nodeInfoEx,
+) ([]string, error) {
+	if len(nodesToRemove) == 0 && len(nodesToAdd) == 0 {
+		return nil, nil
+	}
+
+	ctrlNode := clusterInfo.NodesEx[0]
+
+	d.logger.Debug("selected node for initial add commands",
+		zap.String("address", ctrlNode.IPAddress))
+
+	nodeCtrl := clustercontrol.NodeManager{
+		Endpoint: fmt.Sprintf("http://%s:8091", ctrlNode.IPAddress),
+	}
+
+	d.logger.Info("gathering node images")
+
+	nodesToAddImages, err := d.getImagesForNodeGrps(ctx, nodesToAdd, clusterInfo.IsColumnar())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch images")
+	}
+
+	d.logger.Info("deploying new node containers")
+
+	var deployedNodes []*ContainerInfo
+	var setupNodeOpts []*clustercontrol.AddNodeOptions
+	for nodeGrpIdx, nodeGrp := range nodesToAdd {
+		image := nodesToAddImages[nodeGrpIdx]
+
+		deployOpts := &DeployNodeOptions{
+			Purpose:            clusterInfo.Purpose,
+			ClusterID:          clusterInfo.ClusterID,
+			Image:              image,
+			ImageServerVersion: nodeGrp.Version,
+			IsColumnar:         clusterInfo.IsColumnar(),
+			Expiry:             time.Until(clusterInfo.Expiry),
+			EnvVars:            nodeGrp.Docker.EnvVars,
+		}
+
+		d.logger.Info("deploying node", zap.Any("deployOpts", deployOpts))
+
+		node, err := d.controller.DeployNode(ctx, deployOpts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to deploy a node")
+		}
+
+		nsServices, err := clusterdef.ServicesToNsServices(nodeGrp.Services)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate ns server services list")
+		}
+
+		setupNodeOpts = append(setupNodeOpts, &clustercontrol.AddNodeOptions{
+			ServerGroup: nodeGrp.ServerGroup,
+			Address:     node.IPAddress,
+			Services:    nsServices,
+			Username:    "",
+			Password:    "",
+		})
+
+		deployedNodes = append(deployedNodes, node)
+	}
+
+	if clusterInfo.UsingDinoCerts {
+		d.logger.Info("setting up dinocert certificates", zap.String("cluster", clusterInfo.ClusterID))
+
+		clusterCa, rootCaPem, err := d.getClusterDinoCert(clusterInfo.ClusterID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get cluster dino ca")
+		}
+
+		for _, node := range deployedNodes {
+			err := d.setupNodeCertificates(ctx, node, clusterCa, rootCaPem)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to setup node certificates")
+			}
+		}
+	}
+
+	d.logger.Info("registering new nodes")
+
+	for _, addNodeOpts := range setupNodeOpts {
+		err := nodeCtrl.Controller().AddNode(ctx, addNodeOpts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to register new node")
+		}
+	}
+
+	var nodeIpsBeingRemoved []string
+	for _, node := range nodesToRemove {
+		nodeIpsBeingRemoved = append(nodeIpsBeingRemoved, node.IPAddress)
+	}
+
+	var postRemovalNodes []*nodeInfo
+	for _, clusterNode := range clusterInfo.Nodes {
+		if !slices.Contains(nodeIpsBeingRemoved, clusterNode.IPAddress) {
+			postRemovalNodes = append(postRemovalNodes, clusterNode)
+		}
+	}
+
+	// only need to update if nodes were removed
+	if len(nodesToRemove) > 0 {
+		// only need to update if dns is enabled
+		if clusterInfo.DnsName != "" {
+			err = d.updateDnsRecords(ctx, clusterInfo.DnsName, postRemovalNodes, clusterInfo.IsColumnar(), clusterInfo.LoadBalancerIPAddress(), false)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to update dns records")
+			}
+		}
+
+		for _, node := range clusterInfo.Nodes {
+			if node.IsLoadBalancerNode() {
+				err = d.updateLoadBalancer(ctx, node.ContainerID, postRemovalNodes, clusterInfo.IsColumnar(), clusterInfo.UsingDinoCerts)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to update load balancer")
+				}
+			}
+		}
+	}
+
+	otpsToRemove := make([]string, len(nodesToRemove))
+	for nodeIdx, nodeToRemove := range nodesToRemove {
+		otpsToRemove[nodeIdx] = nodeToRemove.OTPNode
+	}
+
+	// once all the new nodes are registered, we re-select a node to work with that is
+	// not being removed from the cluster, which can now include the new nodes...
+
+	for _, clusterNode := range clusterInfo.NodesEx {
+		if !clusterNode.IsClusterNode() {
+			continue
+		}
+
+		if !slices.Contains(otpsToRemove, clusterNode.OTPNode) {
+			ctrlNode = clusterNode
+		}
+	}
+
+	d.logger.Debug("selected node for remove and rebalance commands",
+		zap.String("address", ctrlNode.IPAddress))
+
+	nodeCtrl = clustercontrol.NodeManager{
+		Endpoint: fmt.Sprintf("http://%s:8091", ctrlNode.IPAddress),
+	}
+
+	d.logger.Info("initiating rebalance")
+
+	err = nodeCtrl.Rebalance(ctx, otpsToRemove)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start rebalance")
+	}
+
+	d.logger.Info("waiting for rebalance completion")
+
+	err = nodeCtrl.WaitForNoRunningTasks(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to wait for tasks to complete")
+	}
+
+	for _, node := range nodesToRemove {
+		d.logger.Info("removing node",
+			zap.String("container", node.ContainerID))
+
+		d.controller.RemoveNode(ctx, node.ContainerID)
+	}
+
+	if len(nodesToAdd) > 0 {
+		thisCluster, err := d.getCluster(ctx, clusterInfo.ClusterID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get post-rebalance cluster info")
+		}
+
+		// no need to update if DNS is disabled
+		if thisCluster.DnsName != "" {
+			err := d.updateDnsRecords(ctx, thisCluster.DnsName, thisCluster.Nodes, thisCluster.IsColumnar(), clusterInfo.LoadBalancerIPAddress(), false)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to update dns records")
+			}
+		}
+
+		for _, node := range clusterInfo.Nodes {
+			if node.IsLoadBalancerNode() {
+				err := d.updateLoadBalancer(ctx, node.ContainerID, thisCluster.Nodes, clusterInfo.IsColumnar(), clusterInfo.UsingDinoCerts)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to update load balancer")
+				}
+			}
+		}
+	}
+
+	var deployedNodeIds []string
+	for _, node := range deployedNodes {
+		deployedNodeIds = append(deployedNodeIds, node.NodeID)
+	}
+
+	return deployedNodeIds, nil
+}
+
+func (d *Deployer) removeNodes(ctx context.Context, nodes []*ContainerInfo) error {
+	var dnsToRemove []string
+	for _, node := range nodes {
+		dnsToRemove = d.appendNodeDnsNames(dnsToRemove, node)
+	}
+
+	waitCh := make(chan error)
+	for _, node := range nodes {
+		go func(node *ContainerInfo) {
+			d.logger.Info("removing node",
+				zap.String("id", node.NodeID),
+				zap.String("container", node.ContainerID))
+
+			d.controller.RemoveNode(ctx, node.ContainerID)
+
+			waitCh <- nil
+		}(node)
+	}
+
+	for range nodes {
+		err := <-waitCh
+		if err != nil {
+			return err
+		}
+	}
+
+	d.removeDnsNames(ctx, dnsToRemove)
+
+	return nil
+}

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -209,6 +209,10 @@ func (d *Deployer) AllowNodeTraffic(ctx context.Context, clusterID string, nodeI
 	return errors.New("localdeploy does not support traffic control")
 }
 
+func (d *Deployer) PartitionNodeTraffic(ctx context.Context, clusterID string, nodeIDs []string) error {
+	return errors.New("localdeploy does not support traffic control")
+}
+
 func (d *Deployer) CollectLogs(ctx context.Context, clusterID string, destPath string) ([]string, error) {
 	return nil, errors.New("localdeploy does not support log collection")
 }


### PR DESCRIPTION
This PR adds a new `partition-traffic <cluster-id> [<node-id-or-ip> ...]` command which allows you to take a portion of a cluster and create a network-partition where node-to-node traffic is interrupted between that set of nodes and the rest of the cluster (creating an island), but where client traffic is still able to arrive at all nodes.