### PR TITLE
SDKQE-3671: Add failover node commands to docker deployer

### DIFF
--- a/cmd/nodes-failover.go
+++ b/cmd/nodes-failover.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"strings"
+)
+
+var nodesFailoverCmd = &cobra.Command{
+	Use:   "failover <cluster-id> <node-id-or-ip>",
+	Short: "Failover a node in the cluster",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		failOverTypeStr, _ := cmd.Flags().GetString("type")
+		allowUnsafe, _ := cmd.Flags().GetBool("allow-unsafe")
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+		node := helper.IdentifyNode(ctx, cluster, args[1])
+
+		var failOverType deployment.FailOverType
+		switch strings.ToLower(failOverTypeStr) {
+		case "hard":
+			failOverType = deployment.HardFailOver
+		case "graceful":
+			failOverType = deployment.GracefulFailOver
+		default:
+			logger.Fatal("unexpected fail over type",
+				zap.String("type", failOverTypeStr))
+		}
+
+		err := deployer.FailOverNode(ctx, cluster.GetID(), node.GetID(), failOverType, allowUnsafe)
+		if err != nil {
+			logger.Fatal("failed to fail over node", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	nodesCmd.AddCommand(nodesFailoverCmd)
+	nodesFailoverCmd.Flags().String("type", "", "the type of failover [hard|graceful]")
+	nodesFailoverCmd.Flags().Bool("allow-unsafe", false, "allow unsafe failover (for hard failover only)")
+}

--- a/cmd/nodes-set-recovery.go
+++ b/cmd/nodes-set-recovery.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"strings"
+)
+
+var nodesSetRecoveryCmd = &cobra.Command{
+	Use:   "set-recovery <cluster-id> <node-id-or-ip>",
+	Short: "Set the recovery type for a node in the cluster",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		recoveryTypeStr, _ := cmd.Flags().GetString("type")
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+		node := helper.IdentifyNode(ctx, cluster, args[1])
+
+		var recoveryType deployment.RecoveryType
+		switch strings.ToLower(recoveryTypeStr) {
+		case "full":
+			recoveryType = deployment.FullRecovery
+		case "delta":
+			recoveryType = deployment.DeltaRecovery
+		default:
+			logger.Fatal("unexpected recovery type",
+				zap.String("type", recoveryTypeStr))
+		}
+
+		err := deployer.SetNodeRecovery(ctx, cluster.GetID(), node.GetID(), recoveryType)
+		if err != nil {
+			logger.Fatal("failed to recovery type", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	nodesCmd.AddCommand(nodesSetRecoveryCmd)
+	nodesSetRecoveryCmd.Flags().String("type", "", "the type of failover recovery [full|delta]")
+}

--- a/cmd/rebalance.go
+++ b/cmd/rebalance.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var rebalanceCmd = &cobra.Command{
+	Use:   "rebalance <cluster-id> [<node-id-or-ip-to-eject> ...]",
+	Short: "Rebalance the cluster, ejecting any specified nodes",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+		nodesToEject := args[1:]
+		var nodeIds []string
+		for _, nodeIdent := range nodesToEject {
+			node := helper.IdentifyNode(ctx, cluster, nodeIdent)
+			nodeIds = append(nodeIds, node.GetID())
+		}
+
+		err := deployer.RebalanceCluster(ctx, cluster.GetID(), nodeIds)
+		if err != nil {
+			logger.Fatal("failed to rebalance cluster", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rebalanceCmd)
+}

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -768,3 +768,15 @@ func (d *Deployer) UpgradeCluster(ctx context.Context, clusterID string, Current
 func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
 	return errors.New("caodeploy does not support enabling data api")
 }
+
+func (d *Deployer) FailOverNode(ctx context.Context, clusterID string, nodeID string, failOverType deployment.FailOverType, allowUnsafe bool) error {
+	return errors.New("caodeploy does not support failing over a node")
+}
+
+func (d *Deployer) SetNodeRecovery(ctx context.Context, clusterID string, nodeID string, recoverType deployment.RecoveryType) error {
+	return errors.New("caodeploy does not support failover recovery")
+}
+
+func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodesToEject []string) error {
+	return errors.New("caodeploy does not support rebalance cluster")
+}

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2467,3 +2467,15 @@ func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeIDs []st
 func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("clouddeploy does not support node pausing")
 }
+
+func (d *Deployer) FailOverNode(ctx context.Context, clusterID string, nodeID string, failOverType deployment.FailOverType, allowUnsafe bool) error {
+	return errors.New("clouddeploy does not support failing over a node")
+}
+
+func (d *Deployer) SetNodeRecovery(ctx context.Context, clusterID string, nodeID string, recoverType deployment.RecoveryType) error {
+	return errors.New("clouddeploy does not support failover recovery")
+}
+
+func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodesToEject []string) error {
+	return errors.New("clouddeploy does not support rebalance cluster")
+}

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -92,6 +92,20 @@ const (
 	BlockNodeTrafficAll     BlockNodeTrafficType = "all"
 )
 
+type FailOverType string
+
+const (
+	HardFailOver     FailOverType = "hard"
+	GracefulFailOver FailOverType = "graceful"
+)
+
+type RecoveryType string
+
+const (
+	FullRecovery  RecoveryType = "full"
+	DeltaRecovery RecoveryType = "delta"
+)
+
 type Deployer interface {
 	ListClusters(ctx context.Context) ([]ClusterInfo, error)
 	NewCluster(ctx context.Context, def *clusterdef.Cluster) (ClusterInfo, error)
@@ -101,6 +115,9 @@ type Deployer interface {
 	UpgradeCluster(ctx context.Context, clusterID string, CurrentImages string, NewImage string) error
 	AddNode(ctx context.Context, clusterID string) (string, error)
 	RemoveNode(ctx context.Context, clusterID string, nodeID string) error
+	FailOverNode(ctx context.Context, clusterID string, nodeID string, failOverType FailOverType, allowUnsafe bool) error
+	SetNodeRecovery(ctx context.Context, clusterID string, nodeID string, recoveryType RecoveryType) error
+	RebalanceCluster(ctx context.Context, clusterID string, nodesToEject []string) error
 	RemoveCluster(ctx context.Context, clusterID string) error
 	RemoveAll(ctx context.Context) error
 	Cleanup(ctx context.Context) error

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -260,3 +260,14 @@ func (d *Deployer) UpgradeCluster(ctx context.Context, clusterID string, Current
 func (d *Deployer) EnableDataApi(ctx context.Context, clusterID string) error {
 	return errors.New("localdeploy does not support enabling data api")
 }
+
+func (d *Deployer) FailOverNode(ctx context.Context, clusterID string, nodeID string, failOverType deployment.FailOverType, allowUnsafe bool) error {
+	return errors.New("localdeploy does not support failing over a node")
+}
+func (d *Deployer) SetNodeRecovery(ctx context.Context, clusterID string, nodeID string, recoverType deployment.RecoveryType) error {
+	return errors.New("localdeploy does not support failover recovery")
+}
+
+func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodesToEject []string) error {
+	return errors.New("localdeploy does not support rebalance cluster")
+}


### PR DESCRIPTION
New commands:
 - 'nodes-failover' with hard/graceful options
 - 'nodes-failover-recover' with recovery type options
 - Both commands have rebalance after option