### PR TITLE
Update pause/unpause cbdino command to accept list of nodes, which can be empty

### DIFF
--- a/cmd/chaos-pausenode.go
+++ b/cmd/chaos-pausenode.go
@@ -6,18 +6,24 @@ import (
 )
 
 var chaosPauseNodeCmd = &cobra.Command{
-	Use:   "pause-node <cluster-id> <node-id-or-ip>",
-	Short: "Pauses a particular node in the cluster.",
-	Args:  cobra.MinimumNArgs(2),
+	Use:   "pause-node <cluster-id> [<node-id-or-ip> ...]",
+	Short: "Pauses node/s present in the cluster.",
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
 		ctx := helper.GetContext()
 
 		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
-		node := helper.IdentifyNode(ctx, cluster, args[1])
+		nodeIdents := args[1:]
 
-		err := deployer.PauseNode(ctx, cluster.GetID(), node.GetID())
+		var nodeIds []string
+		for _, nodeIdent := range nodeIdents {
+			node := helper.IdentifyNode(ctx, cluster, nodeIdent)
+			nodeIds = append(nodeIds, node.GetID())
+		}
+
+		err := deployer.PauseNode(ctx, cluster.GetID(), nodeIds)
 		if err != nil {
 			logger.Fatal("failed to pause node", zap.Error(err))
 		}

--- a/cmd/chaos-unpausenode.go
+++ b/cmd/chaos-unpausenode.go
@@ -6,18 +6,24 @@ import (
 )
 
 var chaosUnpauseNodeCmd = &cobra.Command{
-	Use:   "unpause-node <cluster-id> <node-id-or-ip>",
-	Short: "Unpauses a particular node in the cluster.",
-	Args:  cobra.MinimumNArgs(2),
+	Use:   "unpause-node <cluster-id> [<node-id-or-ip> ...]",
+	Short: "Unpauses node/s present in the cluster.",
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
 		ctx := helper.GetContext()
 
 		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
-		node := helper.IdentifyNode(ctx, cluster, args[1])
+		nodeIdents := args[1:]
 
-		err := deployer.UnpauseNode(ctx, cluster.GetID(), node.GetID())
+		var nodeIds []string
+		for _, nodeIdent := range nodeIdents {
+			node := helper.IdentifyNode(ctx, cluster, nodeIdent)
+			nodeIds = append(nodeIds, node.GetID())
+		}
+
+		err := deployer.UnpauseNode(ctx, cluster.GetID(), nodeIds)
 		if err != nil {
 			logger.Fatal("failed to resume node", zap.Error(err))
 		}

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -737,11 +737,11 @@ func (d *Deployer) SearchImages(ctx context.Context, version string) ([]deployme
 	return nil, errors.New("caodeploy does not support image search")
 }
 
-func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("caodeploy does not support node pausing")
 }
 
-func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("caodeploy does not support node pausing")
 }
 

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2460,10 +2460,10 @@ func (d *Deployer) SearchImages(ctx context.Context, version string) ([]deployme
 	return nil, errors.New("clouddeploy does not support image search")
 }
 
-func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("clouddeploy does not support node pausing")
 }
 
-func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("clouddeploy does not support node pausing")
 }

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -126,8 +126,8 @@ type Deployer interface {
 	CollectLogs(ctx context.Context, clusterID string, destPath string) ([]string, error)
 	ListImages(ctx context.Context) ([]Image, error)
 	SearchImages(ctx context.Context, version string) ([]Image, error)
-	PauseNode(ctx context.Context, clusterID string, nodeID string) error
-	UnpauseNode(ctx context.Context, clusterID string, nodeID string) error
+	PauseNode(ctx context.Context, clusterID string, nodeIDs []string) error
+	UnpauseNode(ctx context.Context, clusterID string, nodeIDs []string) error
 	RedeployCluster(ctx context.Context, clusterID string) error
 	CreateCapellaLink(ctx context.Context, columnarID, linkName, clusterId, directID string) error
 	CreateS3Link(ctx context.Context, columnarID, linkName, region, endpoint, accessKey, secretKey string) error

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -225,11 +225,11 @@ func (d *Deployer) SearchImages(ctx context.Context, version string) ([]deployme
 	return nil, errors.New("localdeploy does not support image search")
 }
 
-func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) PauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("localdeploy does not support node pausing")
 }
 
-func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeID string) error {
+func (d *Deployer) UnpauseNode(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("localdeploy does not support node pausing")
 }
 


### PR DESCRIPTION
Update pause/unpause cbdino command to accept list of nodes, which can be empty. In case of there is no node id passed, pause/unpause each node present in cluster.