### PR TITLE
Implement 'chaos kill-sockets' command

### DIFF
--- a/clusterdef/cluster.go
+++ b/clusterdef/cluster.go
@@ -20,6 +20,8 @@ type DockerCluster struct {
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
 
+	Privileged bool `yaml:"privileged,omitempty"`
+
 	KvMemoryMB       int `yaml:"kv-memory,omitempty"`
 	IndexMemoryMB    int `yaml:"index-memory,omitempty"`
 	FtsMemoryMB      int `yaml:"fts-memory,omitempty"`

--- a/clusterdef/services.go
+++ b/clusterdef/services.go
@@ -2,6 +2,8 @@ package clusterdef
 
 import (
 	"errors"
+	"fmt"
+
 	"github.com/couchbaselabs/cbdinocluster/utils/capellacontrol"
 
 	"golang.org/x/exp/slices"
@@ -130,6 +132,63 @@ func ServicesToCaoServices(services []Service) ([]string, error) {
 		}
 
 		out = append(out, serviceStr)
+	}
+	return out, nil
+}
+
+func ServicesToPorts(services []string) ([]int, error) {
+	var out []int
+	for _, serviceName := range services {
+		service, err := NsServiceToService(serviceName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid service type: %s (%v)", service, err)
+		}
+		switch service {
+		case KvService:
+			out = append(out,
+				/* kv */ 11210,
+				/* kvSSL */ 11207,
+			)
+		case IndexService:
+			out = append(out,
+				/* indexAdmin */ 9100,
+				/* indexHttp */ 9102,
+				/* indexHttps */ 19102,
+				/* indexScan */ 9101,
+				/* indexStreamCatchup */ 9104,
+				/* indexStreamInit */ 9103,
+				/* indexStreamMaint */ 9105,
+			)
+		case QueryService:
+			out = append(out,
+				/* n1ql */ 8093,
+				/* n1qlSSL */ 18093,
+			)
+		case SearchService:
+			out = append(out,
+				/* fts */ 8094,
+				/* ftsGRPC */ 9130,
+				/* ftsGRPCSSL */ 19130,
+				/* ftsSSL */ 18094,
+			)
+		case EventingService:
+			out = append(out,
+				/* eventingAdminPort */ 8096,
+				/* eventingDebug */ 9140,
+				/* eventingSSL */ 18096,
+			)
+		case AnalyticsService:
+			out = append(out,
+				/* cbas */ 8095,
+				/* cbasSSL */ 18095,
+			)
+		case BackupService:
+			out = append(out,
+				/* backupAPI */ 8097,
+				/* backupAPIHTTPS */ 18097,
+				/* backupGRPC */ 9124,
+			)
+		}
 	}
 	return out, nil
 }

--- a/cmd/chaos-killsockets.go
+++ b/cmd/chaos-killsockets.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/couchbaselabs/cbdinocluster/clusterdef"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var chaosKillSocketsCmd = &cobra.Command{
+	Use:   "kill-sockets <cluster-id> [<node-id-or-ip> ...]",
+	Short: "Attempts to forcibly close sockets for the given service.",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+
+		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
+		nodeIdents := args[1:]
+
+		var nodeIds []string
+		for _, nodeIdent := range nodeIdents {
+			node := helper.IdentifyNode(ctx, cluster, nodeIdent)
+			nodeIds = append(nodeIds, node.GetID())
+		}
+
+		services, _ := cmd.Flags().GetStringArray("service")
+
+		err := deployer.KillSockets(ctx, cluster.GetID(), nodeIds, services)
+		if err != nil {
+			logger.Fatal("failed to kill sockets", zap.Error(err))
+		}
+	},
+}
+
+func init() {
+	chaosCmd.AddCommand(chaosKillSocketsCmd)
+
+	chaosKillSocketsCmd.PersistentFlags().StringArray("service", []string{"kv"}, fmt.Sprintf("Service to disrupt. Allowed services: %v",
+		[]clusterdef.Service{
+			clusterdef.KvService,
+			clusterdef.QueryService,
+			clusterdef.IndexService,
+			clusterdef.SearchService,
+			clusterdef.AnalyticsService,
+			clusterdef.EventingService,
+			clusterdef.BackupService,
+		}))
+}

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -784,3 +784,8 @@ func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodes
 func (d *Deployer) KillCouchbase(ctx context.Context, clusterID string, nodes []string) error {
 	return errors.New("caodeploy does not support killing couchbase process")
 }
+
+func (d *Deployer) KillSockets(ctx context.Context, clusterID string, nodeIDs []string, services []string) error {
+	return errors.New("caodeploy does not support killing couchbase sockets")
+}
+

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2483,3 +2483,7 @@ func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodes
 func (d *Deployer) KillCouchbase(ctx context.Context, clusterID string, nodeIDs []string) error {
 	return errors.New("clouddeploy does not support killing couchbase process")
 }
+
+func (d *Deployer) KillSockets(ctx context.Context, clusterID string, nodeIDs []string, services []string) error {
+	return errors.New("clouddeploy does not support killing couchbase sockets")
+}

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -151,4 +151,5 @@ type Deployer interface {
 	DropLink(ctx context.Context, columnarID, linkName string) error
 	EnableDataApi(ctx context.Context, clusterID string) error
 	KillCouchbase(ctx context.Context, clusterID string, nodes []string) error
+	KillSockets(ctx context.Context, clusterID string, nodeIDs []string, services []string) error
 }

--- a/deployment/dockerdeploy/deployer_clusterinfo.go
+++ b/deployment/dockerdeploy/deployer_clusterinfo.go
@@ -51,6 +51,7 @@ type nodeInfo struct {
 	IPAddress            string
 	DnsName              string
 	InitialServerVersion string
+	Privileged           bool
 }
 
 func (i nodeInfo) IsClusterNode() bool {
@@ -113,6 +114,7 @@ func (d *Deployer) listClusters(ctx context.Context) ([]*clusterInfo, error) {
 			IPAddress:            node.IPAddress,
 			DnsName:              node.DnsName,
 			InitialServerVersion: node.InitialServerVersion,
+			Privileged:           node.Privileged,
 		}
 		cluster.Nodes = append(cluster.Nodes, nodeInfo)
 

--- a/deployment/dockerdeploy/deployer_newaddremove.go
+++ b/deployment/dockerdeploy/deployer_newaddremove.go
@@ -277,6 +277,7 @@ func (d *Deployer) newCluster(ctx context.Context, def *clusterdef.Cluster) (*cl
 				Expiry:             def.Expiry,
 				EnvVars:            nodeGrp.Docker.EnvVars,
 				UseDinoCerts:       def.Docker.UseDinoCerts,
+				Privileged:         def.Docker.Privileged,
 			}
 
 			nodeOpts = append(nodeOpts, deployOpts)

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -275,3 +275,8 @@ func (d *Deployer) RebalanceCluster(ctx context.Context, clusterID string, nodes
 func (d *Deployer) KillCouchbase(ctx context.Context, clusterID string, nodes []string) error {
 	return errors.New("localdeploy does not support killing couchbase process")
 }
+
+func (d *Deployer) KillSockets(ctx context.Context, clusterID string, nodeIDs []string, services []string) error {
+	return errors.New("localdeploy does not support killing couchbase sockets")
+}
+

--- a/docs/CHAOS_KILL.md
+++ b/docs/CHAOS_KILL.md
@@ -1,6 +1,6 @@
 ## Chaos kill-couchbase command
 
-Cbdinocluster provides a way to kill couchbase service running 
+Cbdinocluster provides a way to kill couchbase service running
 on a docker container by using `chaos kill-couchbase` command.
 This method is used to simulate a stop and restart of the couchbase server.
 
@@ -9,7 +9,7 @@ This method is used to simulate a stop and restart of the couchbase server.
 If no nodeId is provided, the command will terminate the Couchbase service on all nodes in the cluster.
 If a nodeId is specified, only the Couchbase service on the specified node will be terminated.
 The command should first gather information about the nodes, including the containers on which they are running,
-And it should then simply exec into a Docker container and run `pkill -f couchbase-server` 
+And it should then simply exec into a Docker container and run `pkill -f couchbase-server`
 to terminate the Couchbase service.
 
 The `runSv` supervisor will automatically restart couchbase-server within a few seconds.
@@ -17,7 +17,7 @@ The `runSv` supervisor will automatically restart couchbase-server within a few 
 ### Usage
 
 This command is useful in case where a Couchbase server may be unexpectedly stopped and restarted.
-It allows observing behavior during the transition period when the server is restarting, 
+It allows observing behavior during the transition period when the server is restarting,
 which can reveal issues with connection handling, retries, and error recovery.
 
 ### Kill Couchbase Service
@@ -34,3 +34,81 @@ cbdinocluster chaos kill-couchbase <clusterId> [nodeId]
 | LOCAL    | No        | Not supported for local |
 | CAO      | No        | Not supported for cao   |
 | CLOUD    | No        | Not supported for cloud |
+
+## Chaos kill-sockets command
+
+Cbdinocluster provides a way to kill (shutdown, terminate, close) couchbase
+service sockets running on a docker container by using `chaos kill-sockets`
+command.
+
+This method is used to simulate an unexpected severance of the connection by
+the third party between the server and the SDK.
+
+### What it does
+
+If no `nodeId` is provided, the command closes the connections to all nodes in
+the cluster. If a `nodeId` is specified, only the connections for that node will
+be terminated. The command first gathers information about the nodes, including
+the containers they are running in, and then builds a filter for the `ss(8)`
+command from the [iproute2][iproute2-repo] project using the selected Couchbase
+services (by default, only KV ports are closed).
+
+If the node is running in privileged mode (the cluster definition has the
+`docker.privileged` flag set to `true`), the command will attempt to install
+iproute2 inside the container and terminate the connections locally. Otherwise,
+it attempts to use `ss` on the Docker host. If neither the container is running
+in privileged mode nor the host has `iproute2` installed, the command will fail
+with an error.
+
+### Usage
+
+This command is useful when the network link between the SDK and the Couchbase
+server is unstable but still allows a connection to be established. Unlike the
+chaos `*-traffic` commands, this method does not use firewall rules to block
+traffic. Instead, it only affects connections that are already established at
+the time of command execution. In general, both the SDK and the server are
+resilient to this type of issue, but the command may still uncover hidden
+problems related to resource reuse and operation retries.
+
+### Kill Couchbase Service
+
+Terminate KV connections for all nodes of the cluster
+
+```
+cbdinocluster chaos kill-sockets <clusterId>
+```
+
+Terminate Query and KV connections for the chosen node in the cluster
+
+```
+cbdinocluster chaos kill-sockets <clusterId> [nodeId] --service n1ql --service kv
+```
+
+Sample config that runs containers in privileged mode:
+
+```yaml
+nodes:
+  - count: 4
+    version: 7.6.3-4200
+    services:
+      - kv
+      - n1ql
+      - index
+docker:
+  kv-memory: 2000
+  cbas-memory: 3000
+  fts-memory: 3000
+  privileged: true
+```
+
+
+### Supported Deployers
+
+| Deployer | Supported | Notes                   |
+|----------|-----------|-------------------------|
+| DOCKER   | Yes       | Supported for Docker    |
+| LOCAL    | No        | Not supported for local |
+| CAO      | No        | Not supported for cao   |
+| CLOUD    | No        | Not supported for cloud |
+
+[iproute2-repo]: https://git.kernel.org/pub/scm/network/iproute2/iproute2.git


### PR DESCRIPTION
This command allows to terminate exisiting socket connections to Couchbase services without using firewall rules.