### PR TITLE
Allow setting 0 replicas in buckets add command

### DIFF
--- a/deployment/dockerdeploy/deployer.go
+++ b/deployment/dockerdeploy/deployer.go
@@ -638,11 +638,6 @@ func (d *Deployer) CreateBucket(ctx context.Context, clusterID string, opts *dep
 		ramQuotaMb = opts.RamQuotaMB
 	}
 
-	numReplicas := 1
-	if opts.NumReplicas > 1 {
-		numReplicas = opts.NumReplicas
-	}
-
 	err = agent.CreateBucket(ctx, &cbmgmtx.CreateBucketOptions{
 		BucketName: opts.Name,
 		BucketSettings: cbmgmtx.BucketSettings{
@@ -652,7 +647,7 @@ func (d *Deployer) CreateBucket(ctx context.Context, clusterID string, opts *dep
 			ConflictResolutionType: "seqno",
 			MutableBucketSettings: cbmgmtx.MutableBucketSettings{
 				EvictionPolicy:     "valueOnly",
-				ReplicaNumber:      uint32(numReplicas),
+				ReplicaNumber:      uint32(opts.NumReplicas),
 				DurabilityMinLevel: "none",
 				CompressionMode:    "passive",
 				MaxTTL:             0,


### PR DESCRIPTION
Buckets can be configured to have no replicas, but that's currently not possible with the `buckets add` command. That's useful when deploying single-node clusters.

After this change, the default replica number continues to be 1, as that's the default when the `num-replicas` flag is not present: https://github.com/couchbaselabs/cbdinocluster/blob/e948ceb6badf7e5dc5a76b695e83f5477cbc6acf/cmd/buckets-add.go#L44