### PR TITLE
Bump examples/jwt.yaml cluster version to 8.1.0-1087

### DIFF
--- a/examples/jwt.yaml
+++ b/examples/jwt.yaml
@@ -1,5 +1,5 @@
 nodes:
   - count: 3
-    version: 8.1.0-1064
+    version: 8.1.0-1087
 docker:
   jwt: true


### PR DESCRIPTION
This is the first version that supports omitting the authorization ID.