### PR TITLE
Add --json output flag to all certificate get-* commands

### DIFF
--- a/cmd/certificates-getca.go
+++ b/cmd/certificates-getca.go
@@ -7,6 +7,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type GetCaOutput struct {
+	Cert string `json:"cert"`
+}
+
 var certificatesGetCaCmd = &cobra.Command{
 	Use:   "get-ca <cluster-id>",
 	Short: "Fetches the CA certificate",
@@ -16,6 +20,8 @@ var certificatesGetCaCmd = &cobra.Command{
 		logger := helper.GetLogger()
 		ctx := helper.GetContext()
 
+		outputJson, _ := cmd.Flags().GetBool("json")
+
 		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
 
 		cert, err := deployer.GetCertificate(ctx, cluster.GetID())
@@ -23,7 +29,13 @@ var certificatesGetCaCmd = &cobra.Command{
 			logger.Fatal("failed to get certificate", zap.Error(err))
 		}
 
-		fmt.Printf("%s\n", cert)
+		if !outputJson {
+			fmt.Printf("%s\n", cert)
+		} else {
+			helper.OutputJson(GetCaOutput{
+				Cert: cert,
+			})
+		}
 	},
 }
 

--- a/cmd/certificates-getclientcert.go
+++ b/cmd/certificates-getclientcert.go
@@ -9,6 +9,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type GetClientCertOutput struct {
+	Cert string `json:"cert"`
+	Key  string `json:"key"`
+}
+
 var certificatesGetClientCertCmd = &cobra.Command{
 	Use:   "get-client-cert <username>",
 	Short: "Fetches a client certificate for a specific user",
@@ -19,6 +24,7 @@ var certificatesGetClientCertCmd = &cobra.Command{
 
 		username := args[0]
 		expiresInStr, _ := cmd.Flags().GetString("expires-in")
+		outputJson, _ := cmd.Flags().GetBool("json")
 
 		rootCa, err := dinocerts.GetRootCertAuthority()
 		if err != nil {
@@ -42,7 +48,14 @@ var certificatesGetClientCertCmd = &cobra.Command{
 			logger.Fatal("failed to generate client certificate", zap.Error(err))
 		}
 
-		fmt.Printf("%s\n%s\n", cert, key)
+		if !outputJson {
+			fmt.Printf("%s\n%s\n", cert, key)
+		} else {
+			helper.OutputJson(GetClientCertOutput{
+				Cert: string(cert),
+				Key:  string(key),
+			})
+		}
 	},
 }
 

--- a/cmd/certificates-getdinoca.go
+++ b/cmd/certificates-getdinoca.go
@@ -8,6 +8,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type GetDinoCaOutput struct {
+	Cert string `json:"cert"`
+}
+
 var certificatesGetDinoCaCmd = &cobra.Command{
 	Use:   "get-dino-ca",
 	Short: "Fetches the DinoCert CA certificate",
@@ -15,12 +19,20 @@ var certificatesGetDinoCaCmd = &cobra.Command{
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
 
+		outputJson, _ := cmd.Flags().GetBool("json")
+
 		rootCa, err := dinocerts.GetRootCertAuthority()
 		if err != nil {
 			logger.Fatal("failed to get dino certificate", zap.Error(err))
 		}
 
-		fmt.Printf("%s\n", rootCa.CertPem)
+		if !outputJson {
+			fmt.Printf("%s\n", rootCa.CertPem)
+		} else {
+			helper.OutputJson(GetDinoCaOutput{
+				Cert: string(rootCa.CertPem),
+			})
+		}
 	},
 }
 

--- a/cmd/certificates-getgatewayca.go
+++ b/cmd/certificates-getgatewayca.go
@@ -7,6 +7,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type GetGatewayCaOutput struct {
+	Cert string `json:"cert"`
+}
+
 var certificatesGetGatewayCaCmd = &cobra.Command{
 	Use:   "get-gateway-ca <cluster-id>",
 	Short: "Fetches the Gateway CA certificate",
@@ -16,6 +20,8 @@ var certificatesGetGatewayCaCmd = &cobra.Command{
 		logger := helper.GetLogger()
 		ctx := helper.GetContext()
 
+		outputJson, _ := cmd.Flags().GetBool("json")
+
 		_, deployer, cluster := helper.IdentifyCluster(ctx, args[0])
 
 		cert, err := deployer.GetGatewayCertificate(ctx, cluster.GetID())
@@ -23,7 +29,13 @@ var certificatesGetGatewayCaCmd = &cobra.Command{
 			logger.Fatal("failed to get gateway certificate", zap.Error(err))
 		}
 
-		fmt.Printf("%s\n", cert)
+		if !outputJson {
+			fmt.Printf("%s\n", cert)
+		} else {
+			helper.OutputJson(GetGatewayCaOutput{
+				Cert: cert,
+			})
+		}
 	},
 }
 

--- a/cmd/certificates-getservercert.go
+++ b/cmd/certificates-getservercert.go
@@ -9,6 +9,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type GetServerCertOutput struct {
+	Cert string `json:"cert"`
+	Key  string `json:"key"`
+}
+
 var certificatesGetServerCert = &cobra.Command{
 	Use:   "get-server-cert",
 	Short: "Fetches a server cert configured using the flags",
@@ -16,6 +21,8 @@ var certificatesGetServerCert = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
+
+		outputJson, _ := cmd.Flags().GetBool("json")
 
 		rootCa, err := dinocerts.GetRootCertAuthority()
 		if err != nil {
@@ -40,7 +47,14 @@ var certificatesGetServerCert = &cobra.Command{
 			logger.Fatal("failed to generate server certificate", zap.Error(err))
 		}
 
-		fmt.Printf("%s\n%s\n", cert, key)
+		if !outputJson {
+			fmt.Printf("%s\n%s\n", cert, key)
+		} else {
+			helper.OutputJson(GetServerCertOutput{
+				Cert: string(cert),
+				Key:  string(key),
+			})
+		}
 	},
 }
 


### PR DESCRIPTION
The --json flag enables structured JSON output with separated cert (and key where applicable) fields, replacing the old PEM bundle format.

Before: awk-based parsing of a concatenated bundle was fragile.
After: jq extracts individual fields cleanly.

    cbdinocluster certificates get-client-cert --json Administrator | jq -r '.cert'
    cbdinocluster certificates get-client-cert --json Administrator | jq -r '.key'

instead of something like this:

    cbdinocluster certificates get-client-cert Administrator > /tmp/certs/bundle.pem
    awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' /tmp/certs/bundle.pem > /tmp/certs/client.pem
    awk '/-----BEGIN[^-]*PRIVATE KEY-----/,/-----END[^-]*PRIVATE KEY-----/' /tmp/certs/bundle.pem > /tmp/certs/client.key