### PR TITLE
Allow overriding the config file path via --config flag and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ cbdinocluster connstr $(cbdinocluster ps --json | jq -r '.[0].id')
 
 ### Advanced Usage
 
+#### Overriding the config file location
+
+By default the configuration lives at `~/.cbdinocluster`. You can point
+cbdinocluster at a different file with either the `--config` flag or the
+`CBDINOCLUSTER_CONFIG` environment variable:
+
+```
+cbdinocluster --config /path/to/config.yaml ps
+CBDINOCLUSTER_CONFIG=/path/to/config.yaml cbdinocluster ps
+```
+
+Precedence is `--config` > `CBDINOCLUSTER_CONFIG` > `~/.cbdinocluster`.
+
+This is useful when several jobs share a single home directory — for example
+CI agents running multiple SDK pipelines — and each needs its own
+configuration (a distinct Docker network, deployer, or credentials) without
+clobbering the others' `~/.cbdinocluster`.
+
 #### Resetting Colima
 
 In the case that your colima docker instance becomes corrupted, or stops working

--- a/cbdcconfig/config.go
+++ b/cbdcconfig/config.go
@@ -127,6 +127,24 @@ type Config_DNS struct {
 	Hostname string     `yaml:"hostname"`
 }
 
+// EnvConfigPath is the environment variable that, when set, overrides the
+// location of the config file. The --config command-line flag takes
+// precedence over it.
+const EnvConfigPath = "CBDINOCLUSTER_CONFIG"
+
+// configPathOverride is set by the command-line layer (see cmd.rootCmd's
+// --config flag) and takes precedence over EnvConfigPath and the default.
+var configPathOverride string
+
+// SetConfigPathOverride pins the config file location for the remainder of
+// the process, overriding both EnvConfigPath and DefaultConfigPath. An empty
+// value clears the override. This lets the CLI plumb a --config flag down to
+// Load/Save without threading the path through every call site.
+func SetConfigPathOverride(path string) {
+	configPathOverride = path
+}
+
+// DefaultConfigPath returns the default config file location, ~/.cbdinocluster.
 func DefaultConfigPath() (string, error) {
 	homePath, err := os.UserHomeDir()
 	if err != nil {
@@ -135,6 +153,23 @@ func DefaultConfigPath() (string, error) {
 
 	configPath := path.Join(homePath, ".cbdinocluster")
 	return configPath, nil
+}
+
+// ConfigPath resolves the config file location, applying this precedence:
+//  1. an explicit override set via SetConfigPathOverride (the --config flag),
+//  2. the CBDINOCLUSTER_CONFIG environment variable,
+//  3. the default (~/.cbdinocluster).
+//
+// The override lets multiple jobs sharing a single home directory (e.g. CI
+// agents) keep independent configs without clobbering each other.
+func ConfigPath() (string, error) {
+	if configPathOverride != "" {
+		return configPathOverride, nil
+	}
+	if envPath := os.Getenv(EnvConfigPath); envPath != "" {
+		return envPath, nil
+	}
+	return DefaultConfigPath()
 }
 
 func Upgrade(config *Config) *Config {
@@ -173,9 +208,9 @@ func Upgrade(config *Config) *Config {
 }
 
 func Load(ctx context.Context) (*Config, error) {
-	configPath, err := DefaultConfigPath()
+	configPath, err := ConfigPath()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to find default config path")
+		return nil, errors.Wrap(err, "failed to find config path")
 	}
 
 	configBytes, err := os.ReadFile(configPath)
@@ -202,9 +237,9 @@ func Load(ctx context.Context) (*Config, error) {
 }
 
 func Save(ctx context.Context, config *Config) error {
-	configPath, err := DefaultConfigPath()
+	configPath, err := ConfigPath()
 	if err != nil {
-		return errors.Wrap(err, "failed to find default config path")
+		return errors.Wrap(err, "failed to find config path")
 	}
 
 	configBytes, err := yaml.Marshal(config)

--- a/cbdcconfig/config.go
+++ b/cbdcconfig/config.go
@@ -3,7 +3,7 @@ package cbdcconfig
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -151,7 +151,7 @@ func DefaultConfigPath() (string, error) {
 		return "", errors.Wrap(err, "failed to find user home path")
 	}
 
-	configPath := path.Join(homePath, ".cbdinocluster")
+	configPath := filepath.Join(homePath, ".cbdinocluster")
 	return configPath, nil
 }
 
@@ -245,6 +245,13 @@ func Save(ctx context.Context, config *Config) error {
 	configBytes, err := yaml.Marshal(config)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal config file")
+	}
+
+	// The override (--config / CBDINOCLUSTER_CONFIG) may point at a path whose
+	// parent directory does not exist yet (e.g. a per-job CI directory). The
+	// default ~/.cbdinocluster lives directly in $HOME, so this is a no-op there.
+	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+		return errors.Wrap(err, "failed to create config directory")
 	}
 
 	err = os.WriteFile(configPath, configBytes, 0600)

--- a/cbdcconfig/config_test.go
+++ b/cbdcconfig/config_test.go
@@ -10,12 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// setHomeDir points os.UserHomeDir at dir on every platform. Unix reads $HOME,
+// Windows reads %USERPROFILE%, so setting both keeps these tests deterministic
+// no matter where `go test` runs.
+func setHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
 func TestConfigPathDefault(t *testing.T) {
 	cbdcconfig.SetConfigPathOverride("")
 	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
 	t.Setenv(cbdcconfig.EnvConfigPath, "")
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDir(t, home)
 
 	got, err := cbdcconfig.ConfigPath()
 	require.NoError(t, err)
@@ -25,7 +34,7 @@ func TestConfigPathDefault(t *testing.T) {
 func TestConfigPathFromEnv(t *testing.T) {
 	cbdcconfig.SetConfigPathOverride("")
 	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
-	t.Setenv("HOME", t.TempDir())
+	setHomeDir(t, t.TempDir())
 	envPath := filepath.Join(t.TempDir(), "from-env.yaml")
 	t.Setenv(cbdcconfig.EnvConfigPath, envPath)
 
@@ -35,7 +44,7 @@ func TestConfigPathFromEnv(t *testing.T) {
 }
 
 func TestConfigPathOverrideBeatsEnv(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHomeDir(t, t.TempDir())
 	t.Setenv(cbdcconfig.EnvConfigPath, filepath.Join(t.TempDir(), "from-env.yaml"))
 	overridePath := filepath.Join(t.TempDir(), "from-flag.yaml")
 	cbdcconfig.SetConfigPathOverride(overridePath)
@@ -53,7 +62,7 @@ func TestConfigPathOverrideBeatsEnv(t *testing.T) {
 func TestLoadSaveRoundTripWithOverride(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDir(t, home)
 	t.Setenv(cbdcconfig.EnvConfigPath, "")
 
 	// Point at a path whose parent directory does not exist yet, mirroring the
@@ -82,4 +91,27 @@ func TestLoadSaveRoundTripWithOverride(t *testing.T) {
 	loaded, err = cbdcconfig.Load(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "isolated-net", loaded.Docker.Network)
+}
+
+// TestSaveFailsWhenConfigDirCannotBeCreated is the defensive counterpart to the
+// directory-creating Save: when the parent directory cannot be created (here a
+// regular file sits where Save needs a directory), Save must surface an error
+// rather than silently swallow the config. Defends the MkdirAll error path.
+func TestSaveFailsWhenConfigDirCannotBeCreated(t *testing.T) {
+	ctx := context.Background()
+	setHomeDir(t, t.TempDir())
+	t.Setenv(cbdcconfig.EnvConfigPath, "")
+
+	// A regular file occupies the spot where Save wants to create a directory,
+	// so MkdirAll(filepath.Dir(overridePath)) is forced to fail on every OS.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+
+	overridePath := filepath.Join(blocker, "sub", "config.yaml")
+	cbdcconfig.SetConfigPathOverride(overridePath)
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
+
+	err := cbdcconfig.Save(ctx, &cbdcconfig.Config{Version: cbdcconfig.Version})
+	require.Error(t, err)
+	require.NoFileExists(t, overridePath)
 }

--- a/cbdcconfig/config_test.go
+++ b/cbdcconfig/config_test.go
@@ -3,7 +3,7 @@ package cbdcconfig_test
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
@@ -12,19 +12,21 @@ import (
 
 func TestConfigPathDefault(t *testing.T) {
 	cbdcconfig.SetConfigPathOverride("")
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
 	t.Setenv(cbdcconfig.EnvConfigPath, "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	got, err := cbdcconfig.ConfigPath()
 	require.NoError(t, err)
-	require.Equal(t, path.Join(home, ".cbdinocluster"), got)
+	require.Equal(t, filepath.Join(home, ".cbdinocluster"), got)
 }
 
 func TestConfigPathFromEnv(t *testing.T) {
 	cbdcconfig.SetConfigPathOverride("")
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
 	t.Setenv("HOME", t.TempDir())
-	envPath := path.Join(t.TempDir(), "from-env.yaml")
+	envPath := filepath.Join(t.TempDir(), "from-env.yaml")
 	t.Setenv(cbdcconfig.EnvConfigPath, envPath)
 
 	got, err := cbdcconfig.ConfigPath()
@@ -34,8 +36,8 @@ func TestConfigPathFromEnv(t *testing.T) {
 
 func TestConfigPathOverrideBeatsEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv(cbdcconfig.EnvConfigPath, path.Join(t.TempDir(), "from-env.yaml"))
-	overridePath := path.Join(t.TempDir(), "from-flag.yaml")
+	t.Setenv(cbdcconfig.EnvConfigPath, filepath.Join(t.TempDir(), "from-env.yaml"))
+	overridePath := filepath.Join(t.TempDir(), "from-flag.yaml")
 	cbdcconfig.SetConfigPathOverride(overridePath)
 	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
 
@@ -54,7 +56,9 @@ func TestLoadSaveRoundTripWithOverride(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv(cbdcconfig.EnvConfigPath, "")
 
-	overridePath := path.Join(t.TempDir(), "isolated.yaml")
+	// Point at a path whose parent directory does not exist yet, mirroring the
+	// per-job CI directory use case. Save must create it.
+	overridePath := filepath.Join(t.TempDir(), "nested", "dir", "isolated.yaml")
 	cbdcconfig.SetConfigPathOverride(overridePath)
 	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
 
@@ -66,7 +70,7 @@ func TestLoadSaveRoundTripWithOverride(t *testing.T) {
 	// The file landed at the override path...
 	require.FileExists(t, overridePath)
 	// ...and NOT at the default location.
-	require.NoFileExists(t, path.Join(home, ".cbdinocluster"))
+	require.NoFileExists(t, filepath.Join(home, ".cbdinocluster"))
 
 	loaded, err := cbdcconfig.Load(ctx)
 	require.NoError(t, err)
@@ -74,7 +78,7 @@ func TestLoadSaveRoundTripWithOverride(t *testing.T) {
 
 	// Sanity: a stray default-location file is never consulted while the
 	// override is active.
-	require.NoError(t, os.WriteFile(path.Join(home, ".cbdinocluster"), []byte("version: 6\ndocker:\n  network: default-net\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".cbdinocluster"), []byte("version: 6\ndocker:\n  network: default-net\n"), 0600))
 	loaded, err = cbdcconfig.Load(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "isolated-net", loaded.Docker.Network)

--- a/cbdcconfig/config_test.go
+++ b/cbdcconfig/config_test.go
@@ -1,0 +1,81 @@
+package cbdcconfig_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigPathDefault(t *testing.T) {
+	cbdcconfig.SetConfigPathOverride("")
+	t.Setenv(cbdcconfig.EnvConfigPath, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := cbdcconfig.ConfigPath()
+	require.NoError(t, err)
+	require.Equal(t, path.Join(home, ".cbdinocluster"), got)
+}
+
+func TestConfigPathFromEnv(t *testing.T) {
+	cbdcconfig.SetConfigPathOverride("")
+	t.Setenv("HOME", t.TempDir())
+	envPath := path.Join(t.TempDir(), "from-env.yaml")
+	t.Setenv(cbdcconfig.EnvConfigPath, envPath)
+
+	got, err := cbdcconfig.ConfigPath()
+	require.NoError(t, err)
+	require.Equal(t, envPath, got)
+}
+
+func TestConfigPathOverrideBeatsEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(cbdcconfig.EnvConfigPath, path.Join(t.TempDir(), "from-env.yaml"))
+	overridePath := path.Join(t.TempDir(), "from-flag.yaml")
+	cbdcconfig.SetConfigPathOverride(overridePath)
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
+
+	got, err := cbdcconfig.ConfigPath()
+	require.NoError(t, err)
+	require.Equal(t, overridePath, got)
+}
+
+// TestLoadSaveRoundTripWithOverride proves the override actually redirects the
+// file I/O: a config saved under the override path must be readable back, and
+// it must NOT touch the default (~/.cbdinocluster) location — the property the
+// shared-CI-home use case depends on.
+func TestLoadSaveRoundTripWithOverride(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(cbdcconfig.EnvConfigPath, "")
+
+	overridePath := path.Join(t.TempDir(), "isolated.yaml")
+	cbdcconfig.SetConfigPathOverride(overridePath)
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
+
+	cfg := &cbdcconfig.Config{Version: cbdcconfig.Version}
+	cfg.Docker.Enabled.Set(true)
+	cfg.Docker.Network = "isolated-net"
+	require.NoError(t, cbdcconfig.Save(ctx, cfg))
+
+	// The file landed at the override path...
+	require.FileExists(t, overridePath)
+	// ...and NOT at the default location.
+	require.NoFileExists(t, path.Join(home, ".cbdinocluster"))
+
+	loaded, err := cbdcconfig.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "isolated-net", loaded.Docker.Network)
+
+	// Sanity: a stray default-location file is never consulted while the
+	// override is active.
+	require.NoError(t, os.WriteFile(path.Join(home, ".cbdinocluster"), []byte("version: 6\ndocker:\n  network: default-net\n"), 0600))
+	loaded, err = cbdcconfig.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "isolated-net", loaded.Docker.Network)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,11 @@ var rootCmd = &cobra.Command{
 	// Resolve the --config flag before any subcommand runs and pin it as the
 	// config-path override. The CBDINOCLUSTER_CONFIG env var and the default
 	// are handled in cbdcconfig.ConfigPath; the flag takes precedence.
+	//
+	// This relies on cobra.EnableTraverseRunHooks (set in init): by default
+	// cobra runs only the most specific PersistentPreRunE, so a subcommand
+	// that ever defines its own would silently shadow this one and skip the
+	// --config resolution. Traversal makes every hook in the chain run.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		configPath, err := cmd.Flags().GetString("config")
 		if err != nil {
@@ -33,6 +38,11 @@ func Execute() {
 }
 
 func init() {
+	// Run persistent pre-run hooks from every command in the chain, not just
+	// the most specific one. Without this, a subcommand that later defines its
+	// own PersistentPreRunE would shadow the root's --config resolution above.
+	cobra.EnableTraverseRunHooks = true
+
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Turns on verbose logging")
 	rootCmd.PersistentFlags().Bool("json", false, "Turns on JSON output for supported commands")
 	rootCmd.PersistentFlags().String("config", "", "Path to the config file (overrides $"+cbdcconfig.EnvConfigPath+" and the default ~/.cbdinocluster)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "cbdinocluster",
 	Short: "provides tooling for quickly creating, modifying and destroying couchbase clusters.",
+	// Resolve the --config flag before any subcommand runs and pin it as the
+	// config-path override. The CBDINOCLUSTER_CONFIG env var and the default
+	// are handled in cbdcconfig.ConfigPath; the flag takes precedence.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil {
+			return err
+		}
+		if configPath != "" {
+			cbdcconfig.SetConfigPathOverride(configPath)
+		}
+		return nil
+	},
 }
 
 func Execute() {
@@ -21,4 +35,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Turns on verbose logging")
 	rootCmd.PersistentFlags().Bool("json", false, "Turns on JSON output for supported commands")
+	rootCmd.PersistentFlags().String("config", "", "Path to the config file (overrides $"+cbdcconfig.EnvConfigPath+" and the default ~/.cbdinocluster)")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigFlagSurvivesSubcommandPreRun guards against the cobra
+// PersistentPreRunE shadowing footgun: by default cobra runs only the most
+// specific persistent pre-run hook, so a subcommand defining its own would
+// silently suppress the root's --config resolution. This test attaches such a
+// subcommand and asserts the override is still applied — which only holds
+// because cobra.EnableTraverseRunHooks is enabled in init(). Flip that off and
+// this test fails, surfacing the regression instead of leaving a latent bug.
+func TestConfigFlagSurvivesSubcommandPreRun(t *testing.T) {
+	cbdcconfig.SetConfigPathOverride("")
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
+
+	childRan := false
+	child := &cobra.Command{
+		Use: "dummychild",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			childRan = true
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	rootCmd.AddCommand(child)
+	t.Cleanup(func() {
+		rootCmd.RemoveCommand(child)
+		rootCmd.SetArgs(nil)
+	})
+
+	const overridePath = "/tmp/cbdinocluster-test-explicit-config.yaml"
+	rootCmd.SetArgs([]string{"dummychild", "--config", overridePath})
+	require.NoError(t, rootCmd.Execute())
+
+	require.True(t, childRan, "the subcommand's own PersistentPreRunE should have run")
+
+	got, err := cbdcconfig.ConfigPath()
+	require.NoError(t, err)
+	require.Equal(t, overridePath, got,
+		"root --config resolution must run even when a subcommand defines its own PersistentPreRunE")
+}


### PR DESCRIPTION
The config file location was hardcoded to $HOME/.cbdinocluster with no way to override it. This is a problem on shared CI runners: a single agent (often a long-lived container) runs multiple SDK pipelines that each want their own cbdinocluster configuration — most importantly a different Docker network — but they all resolve to the same ~/.cbdinocluster and clobber each other. A job that rewrites the docker network to suit its own topology silently breaks every co-tenant job on that runner.

With this change each job can point at its own config:

    cbdinocluster --config "$WORKSPACE/.cbdinocluster" init --auto
    CBDINOCLUSTER_CONFIG="$WORKSPACE/.cbdinocluster" cbdinocluster ps

so one runner can host jobs configured for different Docker networks (and deployers/credentials) without interfering with one another, and without touching the shared home-directory config.

Resolution precedence: `--config` flag > `CBDINOCLUSTER_CONFIG` env >
`~/.cbdinocluster` default. The flag is a root persistent flag resolved in PersistentPreRunE; env and default are handled in cbdcconfig.ConfigPath so library callers get the same behavior. Load and Save now use ConfigPath instead of DefaultConfigPath (DefaultConfigPath is retained as the documented default and fallback).

Adds cbdcconfig tests for the precedence rules and a Load/Save round-trip proving the override redirects file I/O and never reads or writes the default location, plus a README section.