### PR TITLE
Sign the gateway's certificate with the Dino CA

### DIFF
--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -321,12 +321,20 @@ func (d *Deployer) generateClusterSpec(
 		serversRes = append(serversRes, serverEntry)
 	}
 
+	cngEnabled := def.Cao.GatewayVersion != ""
+
 	cngSpec := make(map[string]interface{})
 	if gatewayImagePath != "" {
 		cngSpec["image"] = gatewayImagePath
 	}
 	if gatewayLogLevel != "" {
 		cngSpec["logLevel"] = gatewayLogLevel
+	}
+	if cngEnabled {
+		// Serve our Dino-signed cert instead of the operator's self-signed one.
+		cngSpec["tls"] = map[string]interface{}{
+			"serverSecretName": CngTlsSecretName,
+		}
 	}
 
 	if len(cngSpec) == 0 {
@@ -410,6 +418,13 @@ func (d *Deployer) NewCluster(ctx context.Context, def *clusterdef.Cluster) (dep
 		return nil, errors.Wrap(err, "failed to create admin auth")
 	}
 
+	if def.Cao.GatewayVersion != "" {
+		err = d.provisionGatewayTLSSecret(ctx, clusterID.String(), namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to provision gateway tls secret")
+		}
+	}
+
 	clusterAnnotations, clusterSpec, err := d.generateClusterSpec(ctx, def, isOpenShift)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate cluster spec")
@@ -481,6 +496,13 @@ func (d *Deployer) ModifyCluster(ctx context.Context, clusterID string, def *clu
 	namespaceName, err := d.getClusterNamespace(ctx, clusterID)
 	if err != nil {
 		return err
+	}
+
+	if def.Cao.GatewayVersion != "" {
+		err = d.provisionGatewayTLSSecret(ctx, clusterID, namespaceName)
+		if err != nil {
+			return errors.Wrap(err, "failed to provision gateway tls secret")
+		}
 	}
 
 	clusterAnnotations, clusterSpec, err := d.generateClusterSpec(ctx, def, isOpenShift)
@@ -1009,22 +1031,14 @@ func (d *Deployer) GetCertificate(ctx context.Context, clusterID string) (string
 }
 
 func (d *Deployer) GetGatewayCertificate(ctx context.Context, clusterID string) (string, error) {
-	namespaceName, err := d.getClusterNamespace(ctx, clusterID)
+	// The gateway CA is deterministic, so regenerate it instead of reading the
+	// secret back from the cluster.
+	gatewayCa, _, err := getGatewayDinoCA(clusterID)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to get gateway CA")
 	}
 
-	secret, err := d.client.GetSecret(ctx, namespaceName, "couchbase-cloud-native-gateway-self-signed-secret-cluster")
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get secret")
-	}
-
-	secretData := secret.Data["tls.crt"]
-	if len(secretData) == 0 {
-		return "", errors.New("secret data was unexpectedly empty")
-	}
-
-	return string(secretData), nil
+	return string(gatewayCa.CertPem), nil
 }
 
 func (d *Deployer) GetMetrics(ctx context.Context, clusterID string) (string, error) {

--- a/deployment/caodeploy/deployer_certs.go
+++ b/deployment/caodeploy/deployer_certs.go
@@ -1,0 +1,117 @@
+package caodeploy
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/couchbaselabs/cbdinocluster/utils/dinocerts"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CngTlsSecretName holds our Dino-signed gateway cert. Without it the operator
+// serves its own self-signed cert, which doesn't chain to the Dino root.
+const CngTlsSecretName = "cbdc2-cng-tls"
+
+// getGatewayDinoCA returns the cluster's gateway CA: an intermediate signed by
+// the Root Dino CA, derived deterministically from the cluster id.
+func getGatewayDinoCA(clusterID string) (*dinocerts.CertAuthority, []byte, error) {
+	rootCa, err := dinocerts.GetRootCertAuthority()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get root dino ca")
+	}
+
+	gatewayCa, err := rootCa.MakeIntermediaryCA("gateway-" + clusterID[:8])
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to make gateway dino ca")
+	}
+
+	return gatewayCa, rootCa.CertPem, nil
+}
+
+// buildGatewayTLSSecretData builds the gateway TLS secret: tls.crt is leaf +
+// gateway CA, tls.key the leaf key, ca.crt gateway CA + Root Dino CA.
+func buildGatewayTLSSecretData(
+	clusterID string,
+	dnsNames []string,
+	ipAddresses []net.IP,
+) (map[string][]byte, error) {
+	gatewayCa, rootCaPem, err := getGatewayDinoCA(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Name the leaf distinctly from the CA, or it reuses the CA's key and
+	// subject and looks self-signed.
+	leafPem, keyPem, err := gatewayCa.MakeServerCertificate("gateway-server-"+clusterID[:8], ipAddresses, dnsNames)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to make gateway server certificate")
+	}
+
+	var tlsChain []byte
+	tlsChain = append(tlsChain, leafPem...)
+	tlsChain = append(tlsChain, gatewayCa.CertPem...)
+
+	var caChain []byte
+	caChain = append(caChain, gatewayCa.CertPem...)
+	caChain = append(caChain, rootCaPem...)
+
+	return map[string][]byte{
+		"tls.crt": tlsChain,
+		"tls.key": keyPem,
+		"ca.crt":  caChain,
+	}, nil
+}
+
+// gatewayServerDNSNames lists the hostnames the gateway leaf is valid for.
+// NodePort access is by node IP (not known here), so that path relies on the
+// SDK skipping the hostname check.
+func (d *Deployer) gatewayServerDNSNames(ctx context.Context, clusterID string, namespace string) []string {
+	dnsNames := []string{
+		"localhost",
+		CngServiceName,
+		fmt.Sprintf("%s.%s", CngServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc", CngServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", CngServiceName, namespace),
+	}
+
+	if d.sharedGateway != "" {
+		baseDomain, err := d.getSharedGatewayBaseDomain(ctx)
+		if err != nil {
+			d.logger.Warn("failed to resolve shared gateway base domain for gateway cert", zap.Error(err))
+		} else {
+			dnsNames = append(dnsNames, fmt.Sprintf("cng-%s.%s", clusterID, baseDomain))
+		}
+	}
+
+	return dnsNames
+}
+
+func (d *Deployer) provisionGatewayTLSSecret(ctx context.Context, clusterID string, namespace string) error {
+	dnsNames := d.gatewayServerDNSNames(ctx, clusterID, namespace)
+
+	secretData, err := buildGatewayTLSSecretData(clusterID, dnsNames, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to build gateway tls secret data")
+	}
+
+	d.logger.Info("provisioning dino gateway tls secret",
+		zap.String("secret", CngTlsSecretName),
+		zap.Strings("dnsNames", dnsNames))
+
+	err = d.client.CreateSecret(ctx, namespace, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: CngTlsSecretName,
+		},
+		Data: secretData,
+		Type: corev1.SecretTypeTLS,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create gateway tls secret")
+	}
+
+	return nil
+}

--- a/deployment/caodeploy/deployer_certs_test.go
+++ b/deployment/caodeploy/deployer_certs_test.go
@@ -1,0 +1,124 @@
+package caodeploy
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/utils/dinocerts"
+	"github.com/stretchr/testify/require"
+)
+
+const testClusterID = "abcdef0123456789"
+
+func parseCerts(t *testing.T, pemBytes []byte) []*x509.Certificate {
+	t.Helper()
+
+	var certs []*x509.Certificate
+	rest := pemBytes
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		require.Equal(t, "CERTIFICATE", block.Type)
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		certs = append(certs, cert)
+	}
+
+	require.NotEmpty(t, certs, "expected at least one PEM certificate")
+	return certs
+}
+
+// The gateway CA must be a real CA signed by the Root Dino CA.
+func TestGatewayCAIsSignedByRoot(t *testing.T) {
+	root, err := dinocerts.GetRootCertAuthority()
+	require.NoError(t, err)
+
+	gatewayCa, rootCaPem, err := getGatewayDinoCA(testClusterID)
+	require.NoError(t, err)
+
+	require.Equal(t, string(root.CertPem), string(rootCaPem))
+
+	gatewayCaCert := parseCerts(t, gatewayCa.CertPem)[0]
+	require.True(t, gatewayCaCert.IsCA, "gateway CA must be a CA")
+	require.NotZero(t, gatewayCaCert.KeyUsage&x509.KeyUsageCertSign, "gateway CA must be allowed to sign certs")
+
+	rootCert := parseCerts(t, root.CertPem)[0]
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCert)
+	_, err = gatewayCaCert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	require.NoError(t, err, "gateway CA must verify against the Root Dino CA")
+}
+
+// The provisioned secret must form a full chain: leaf -> gateway CA -> Root Dino CA.
+func TestGatewayTLSSecretChainValidates(t *testing.T) {
+	root, err := dinocerts.GetRootCertAuthority()
+	require.NoError(t, err)
+	rootCert := parseCerts(t, root.CertPem)[0]
+
+	dnsNames := []string{"cluster-cloud-native-gateway-service", "cng-test.example.com"}
+	secretData, err := buildGatewayTLSSecretData(testClusterID, dnsNames, nil)
+	require.NoError(t, err)
+
+	// tls.crt is a chain of [leaf, gateway CA].
+	tlsCerts := parseCerts(t, secretData["tls.crt"])
+	require.Len(t, tlsCerts, 2)
+	leaf := tlsCerts[0]
+	require.False(t, leaf.IsCA, "tls.crt must lead with a leaf certificate")
+	require.ElementsMatch(t, dnsNames, leaf.DNSNames)
+
+	// ca.crt is a bundle of [gateway CA, root].
+	caCerts := parseCerts(t, secretData["ca.crt"])
+	require.Len(t, caCerts, 2)
+	gatewayCaCert := caCerts[0]
+	require.True(t, gatewayCaCert.IsCA, "ca.crt must lead with the gateway CA")
+	require.Equal(t, rootCert.Subject.String(), caCerts[1].Subject.String())
+
+	// Leaf must have its own subject and key and be signed by the CA, not be a
+	// copy of the CA that looks self-signed.
+	require.NotEqual(t, gatewayCaCert.Subject.String(), leaf.Subject.String(),
+		"leaf and gateway CA must not share a subject")
+	require.NotEqual(t, leaf.SubjectKeyId, leaf.AuthorityKeyId,
+		"leaf must be signed by the CA's key, not its own")
+	require.Equal(t, gatewayCaCert.SubjectKeyId, leaf.AuthorityKeyId,
+		"leaf's authority key id must point at the gateway CA")
+
+	// The leaf must validate up to the root using the gateway CA as intermediate.
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCert)
+	intermediates := x509.NewCertPool()
+	intermediates.AddCert(caCerts[0])
+
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		DNSName:       "cng-test.example.com",
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err, "gateway leaf must chain to the Root Dino CA")
+}
+
+// `get-gateway-ca` must return the CA that signs the leaf, not the leaf itself.
+func TestGetGatewayCertificateMatchesProvisionedCA(t *testing.T) {
+	gatewayCa, _, err := getGatewayDinoCA(testClusterID)
+	require.NoError(t, err)
+
+	secretData, err := buildGatewayTLSSecretData(testClusterID, nil, nil)
+	require.NoError(t, err)
+
+	returnedCA := parseCerts(t, gatewayCa.CertPem)[0]
+	require.True(t, returnedCA.IsCA)
+
+	leaf := parseCerts(t, secretData["tls.crt"])[0]
+	require.False(t, leaf.IsCA)
+
+	require.NoError(t, leaf.CheckSignatureFrom(returnedCA),
+		"provisioned leaf must be signed by the gateway CA returned by get-gateway-ca")
+}


### PR DESCRIPTION
`cbdino certificates get-gateway-ca` used to return the gateway's leaf certificate which wasn't signed by the DinoRoot, which broke chain validation.

This PR makes it so the SDK is presented with the gateway's leaf and CA when connecting, so the chain can properly validated up to the root, and so `get-gateway-ca` properly returns the Gateway's CA.