### PR TITLE
Support ephemeral and memcached buckets in `buckets add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Useful for testing magma buckets, advanced search indexes (1536mb for KV, 1024mb
 ./cbdinocluster buckets add {{CLUSTER_ID}} default --ram-quota-mb=100 --flush-enabled=true
 ```
 
+Use `--bucket-type` to select the bucket type. Valid values are `couchbase`
+(the default) and `ephemeral`. `memcached` is also accepted, but it is a legacy
+type that Couchbase Server 8.0 and later reject ("memcached buckets are no
+longer supported"); it can only be created on older clusters.
+
+```
+./cbdinocluster buckets add {{CLUSTER_ID}} cache --bucket-type=ephemeral --ram-quota-mb=100
+```
+
 #### Create a collection in the default scope on the bucket named `default`
 
 ```

--- a/clusterdef/cluster.go
+++ b/clusterdef/cluster.go
@@ -23,9 +23,10 @@ type Bucket struct {
 }
 
 type Settings struct {
-	RamQuotaMB   int  `yaml:"ram-quota-mb,omitempty"`
-	FlushEnabled bool `yaml:"flush-enabled,omitempty"`
-	NumReplicas  int  `yaml:"num-replicas,omitempty"`
+	BucketType   string `yaml:"bucket-type,omitempty"`
+	RamQuotaMB   int    `yaml:"ram-quota-mb,omitempty"`
+	FlushEnabled bool   `yaml:"flush-enabled,omitempty"`
+	NumReplicas  int    `yaml:"num-replicas,omitempty"`
 }
 
 type Scopes map[string]Collections

--- a/cmd/allocate.go
+++ b/cmd/allocate.go
@@ -57,6 +57,23 @@ var allocateCmd = &cobra.Command{
 			def.Cloud.CloudProvider = cloudProvider
 		}
 
+		// Validate and assemble the bucket options up-front so that an invalid
+		// bucket type fails fast, before the cluster is allocated.
+		bucketOpts := make(map[string]*deployment.CreateBucketOptions, len(def.Buckets))
+		for bucketName, bucketDef := range def.Buckets {
+			opts, err := newCreateBucketOptions(
+				bucketName,
+				bucketDef.Settings.BucketType,
+				bucketDef.Settings.RamQuotaMB,
+				bucketDef.Settings.FlushEnabled,
+				bucketDef.Settings.NumReplicas,
+			)
+			if err != nil {
+				logger.Fatal("invalid bucket type", zap.String("bucket", bucketName), zap.Error(err))
+			}
+			bucketOpts[bucketName] = opts
+		}
+
 		logger.Info("deploying definition", zap.Any("def", def))
 
 		if dryRun {
@@ -77,12 +94,7 @@ var allocateCmd = &cobra.Command{
 
 		if len(def.Buckets) > 0 {
 			for bucketName, bucketDef := range def.Buckets {
-				err := deployer.CreateBucket(ctx, cluster.GetID(), &deployment.CreateBucketOptions{
-					Name:         bucketName,
-					RamQuotaMB:   bucketDef.Settings.RamQuotaMB,
-					FlushEnabled: bucketDef.Settings.FlushEnabled,
-					NumReplicas:  bucketDef.Settings.NumReplicas,
-				})
+				err = deployer.CreateBucket(ctx, cluster.GetID(), bucketOpts[bucketName])
 				if err != nil {
 					logger.Fatal("failed to create bucket", zap.String("bucket", bucketName), zap.Error(err))
 				}

--- a/cmd/buckets-add.go
+++ b/cmd/buckets-add.go
@@ -23,15 +23,16 @@ var bucketsAddCmd = &cobra.Command{
 		ramQuotaMB, _ := cmd.Flags().GetInt("ram-quota-mb")
 		flushEnabled, _ := cmd.Flags().GetBool("flush-enabled")
 		numReplicas, _ := cmd.Flags().GetInt("num-replicas")
+		bucketTypeStr, _ := cmd.Flags().GetString("bucket-type")
+
+		createOpts, err := newCreateBucketOptions(bucketName, bucketTypeStr, ramQuotaMB, flushEnabled, numReplicas)
+		if err != nil {
+			logger.Fatal("invalid bucket type", zap.Error(err))
+		}
 
 		_, deployer, cluster := helper.IdentifyCluster(ctx, clusterID)
 
-		err := deployer.CreateBucket(ctx, cluster.GetID(), &deployment.CreateBucketOptions{
-			Name:         bucketName,
-			RamQuotaMB:   ramQuotaMB,
-			FlushEnabled: flushEnabled,
-			NumReplicas:  numReplicas,
-		})
+		err = deployer.CreateBucket(ctx, cluster.GetID(), createOpts)
 		if err != nil {
 			if errors.Is(err, deployment.ErrBucketAlreadyExists) {
 				logger.Fatal("failed to create bucket as it already exists")
@@ -41,9 +42,28 @@ var bucketsAddCmd = &cobra.Command{
 	},
 }
 
+// newCreateBucketOptions parses the user-supplied bucket type and assembles the
+// CreateBucketOptions shared by the `buckets add` command and the YAML-driven
+// allocate path. It returns an error for an unrecognized bucket type.
+func newCreateBucketOptions(name, bucketTypeStr string, ramQuotaMB int, flushEnabled bool, numReplicas int) (*deployment.CreateBucketOptions, error) {
+	bucketType, err := deployment.ParseBucketType(bucketTypeStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deployment.CreateBucketOptions{
+		Name:         name,
+		BucketType:   bucketType,
+		RamQuotaMB:   ramQuotaMB,
+		FlushEnabled: flushEnabled,
+		NumReplicas:  numReplicas,
+	}, nil
+}
+
 func init() {
 	bucketsCmd.AddCommand(bucketsAddCmd)
 
+	bucketsAddCmd.Flags().String("bucket-type", "couchbase", "The type of bucket to create: couchbase (default) or ephemeral. memcached is a legacy type that Couchbase Server 8.0+ rejects and is only creatable on older clusters.")
 	bucketsAddCmd.Flags().Int("ram-quota-mb", 0, "The amount of RAM to provide for the bucket.")
 	bucketsAddCmd.Flags().Bool("flush-enabled", false, "Whether flush is enabled on the bucket.")
 	bucketsAddCmd.Flags().Int("num-replicas", 1, "The number of replicas for the bucket.")

--- a/cmd/buckets-add_test.go
+++ b/cmd/buckets-add_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBucketsAddBucketTypeFlag guards the CLI surface for the bucket type:
+// the flag must exist and default to "couchbase" so that existing invocations
+// (which never passed a type) keep creating couchbase buckets.
+func TestBucketsAddBucketTypeFlag(t *testing.T) {
+	flag := bucketsAddCmd.Flags().Lookup("bucket-type")
+	require.NotNil(t, flag, "buckets add must expose a --bucket-type flag")
+	require.Equal(t, "couchbase", flag.DefValue)
+}
+
+// TestNewCreateBucketOptionsWiring asserts that the parsed bucket type and the
+// remaining bucket settings actually land in the CreateBucketOptions handed to
+// the deployer. This is the glue between the CLI flags and the deployer that
+// the flag-default test alone does not cover.
+func TestNewCreateBucketOptionsWiring(t *testing.T) {
+	tests := []struct {
+		name           string
+		bucketTypeStr  string
+		wantBucketType deployment.BucketType
+	}{
+		{name: "flag default", bucketTypeStr: "couchbase", wantBucketType: deployment.BucketTypeCouchbase},
+		{name: "empty defaults to couchbase", bucketTypeStr: "", wantBucketType: deployment.BucketTypeCouchbase},
+		{name: "ephemeral", bucketTypeStr: "ephemeral", wantBucketType: deployment.BucketTypeEphemeral},
+		{name: "memcached", bucketTypeStr: "memcached", wantBucketType: deployment.BucketTypeMemcached},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := newCreateBucketOptions("mybucket", tt.bucketTypeStr, 256, true, 2)
+			require.NoError(t, err)
+			require.Equal(t, "mybucket", opts.Name)
+			require.Equal(t, tt.wantBucketType, opts.BucketType)
+			require.Equal(t, 256, opts.RamQuotaMB)
+			require.True(t, opts.FlushEnabled)
+			require.Equal(t, 2, opts.NumReplicas)
+		})
+	}
+}
+
+func TestNewCreateBucketOptionsInvalidType(t *testing.T) {
+	opts, err := newCreateBucketOptions("mybucket", "nonsense", 0, false, 0)
+	require.Error(t, err)
+	require.Nil(t, opts)
+}
+
+// TestBucketsAddFlagDefaultIsValid ties the flag default to the parser: the
+// default string must be a bucket type the option-builder accepts, so the
+// zero-config path can never fail validation in the command's Run.
+func TestBucketsAddFlagDefaultIsValid(t *testing.T) {
+	flag := bucketsAddCmd.Flags().Lookup("bucket-type")
+	require.NotNil(t, flag)
+
+	opts, err := newCreateBucketOptions("b", flag.DefValue, 0, false, 0)
+	require.NoError(t, err)
+	require.Equal(t, deployment.BucketTypeCouchbase, opts.BucketType)
+}

--- a/deployment/buckets.go
+++ b/deployment/buckets.go
@@ -1,0 +1,50 @@
+package deployment
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BucketType identifies which kind of Couchbase bucket to create. The values
+// are the canonical, user-facing names; ParseBucketType maps the various
+// aliases (and the server-internal "membase" name) onto these.
+type BucketType string
+
+const (
+	// BucketTypeCouchbase is a persistent, replicated bucket (the server
+	// internally calls this "membase"). It is the default.
+	BucketTypeCouchbase BucketType = "couchbase"
+	// BucketTypeEphemeral is a memory-only replicated bucket with no disk
+	// persistence.
+	BucketTypeEphemeral BucketType = "ephemeral"
+	// BucketTypeMemcached is a non-replicated, memory-only cache bucket. It is
+	// a legacy type that Couchbase Server 8.0 and later reject; it is only
+	// creatable on older clusters.
+	BucketTypeMemcached BucketType = "memcached"
+)
+
+// AllBucketTypes lists every supported bucket type. It is the single list each
+// deployer's per-type mapping is expected to handle; tests iterate it to catch
+// a newly-added type that a deployer forgot to map.
+var AllBucketTypes = []BucketType{
+	BucketTypeCouchbase,
+	BucketTypeEphemeral,
+	BucketTypeMemcached,
+}
+
+// ParseBucketType normalizes a user-supplied bucket type string into a
+// BucketType. An empty string defaults to BucketTypeCouchbase. Both the
+// user-facing "couchbase" and the server-internal "membase" names are
+// accepted. It returns an error for any unrecognized value.
+func ParseBucketType(s string) (BucketType, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "couchbase", "membase":
+		return BucketTypeCouchbase, nil
+	case "ephemeral":
+		return BucketTypeEphemeral, nil
+	case "memcached":
+		return BucketTypeMemcached, nil
+	default:
+		return "", fmt.Errorf("invalid bucket type %q (valid types: couchbase, ephemeral, memcached)", s)
+	}
+}

--- a/deployment/buckets_test.go
+++ b/deployment/buckets_test.go
@@ -1,0 +1,60 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBucketType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    BucketType
+		wantErr bool
+	}{
+		{name: "empty defaults to couchbase", input: "", want: BucketTypeCouchbase},
+		{name: "whitespace-only defaults to couchbase", input: "   ", want: BucketTypeCouchbase},
+		{name: "couchbase", input: "couchbase", want: BucketTypeCouchbase},
+		{name: "membase alias", input: "membase", want: BucketTypeCouchbase},
+		{name: "ephemeral", input: "ephemeral", want: BucketTypeEphemeral},
+		{name: "memcached", input: "memcached", want: BucketTypeMemcached},
+		{name: "uppercase is normalized", input: "EPHEMERAL", want: BucketTypeEphemeral},
+		{name: "surrounding whitespace is trimmed", input: "  memcached  ", want: BucketTypeMemcached},
+		{name: "mixed case couchbase", input: "Couchbase", want: BucketTypeCouchbase},
+		{name: "invalid value errors", input: "nonsense", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBucketType(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got, "an error must return the zero-value bucket type")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseBucketTypeErrorMessageListsValidTypes(t *testing.T) {
+	_, err := ParseBucketType("nonsense")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couchbase")
+	require.Contains(t, err.Error(), "ephemeral")
+	require.Contains(t, err.Error(), "memcached")
+}
+
+// TestAllBucketTypesParse guards that every canonical value in AllBucketTypes
+// round-trips through ParseBucketType, so the list and the parser cannot drift.
+func TestAllBucketTypesParse(t *testing.T) {
+	for _, bt := range AllBucketTypes {
+		t.Run(string(bt), func(t *testing.T) {
+			got, err := ParseBucketType(string(bt))
+			require.NoError(t, err)
+			require.Equal(t, bt, got)
+		})
+	}
+}

--- a/deployment/clouddeploy/buckets_test.go
+++ b/deployment/clouddeploy/buckets_test.go
@@ -1,0 +1,68 @@
+package clouddeploy
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapellaBucketParams(t *testing.T) {
+	tests := []struct {
+		name               string
+		bucketType         deployment.BucketType
+		wantType           string
+		wantStorageBackend string
+		wantErr            bool
+	}{
+		{
+			name:               "empty defaults to couchbase",
+			bucketType:         "",
+			wantType:           "couchbase",
+			wantStorageBackend: "couchstore",
+		},
+		{
+			name:               "couchbase",
+			bucketType:         deployment.BucketTypeCouchbase,
+			wantType:           "couchbase",
+			wantStorageBackend: "couchstore",
+		},
+		{
+			// Ephemeral must report an empty storage backend so the request
+			// omits it (the Capella API rejects a disk backend for ephemeral).
+			name:               "ephemeral clears storage backend",
+			bucketType:         deployment.BucketTypeEphemeral,
+			wantType:           "ephemeral",
+			wantStorageBackend: "",
+		},
+		{
+			name:       "memcached is rejected",
+			bucketType: deployment.BucketTypeMemcached,
+			wantErr:    true,
+		},
+		{
+			name:       "unknown type is rejected",
+			bucketType: deployment.BucketType("nonsense"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capellaType, storageBackend, err := capellaBucketParams(tt.bucketType)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, capellaType)
+			require.Equal(t, tt.wantStorageBackend, storageBackend)
+		})
+	}
+}
+
+func TestCapellaBucketParamsMemcachedMessage(t *testing.T) {
+	_, _, err := capellaBucketParams(deployment.BucketTypeMemcached)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "memcached")
+}

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -2021,6 +2021,11 @@ func (p *Deployer) CreateBucket(ctx context.Context, clusterID string, opts *dep
 		numReplicas = opts.NumReplicas
 	}
 
+	capellaBucketType, storageBackend, err := capellaBucketParams(opts.BucketType)
+	if err != nil {
+		return err
+	}
+
 	err = p.mgr.Client.CreateBucket(ctx, p.tenantID, clusterInfo.Cluster.Project.Id, clusterInfo.Cluster.Id, &capellacontrol.CreateBucketRequest{
 		BucketConflictResolution: "seqno",
 		DurabilityLevel:          "none",
@@ -2028,14 +2033,37 @@ func (p *Deployer) CreateBucket(ctx context.Context, clusterID string, opts *dep
 		MemoryAllocationInMB:     ramQuotaMb,
 		Name:                     opts.Name,
 		Replicas:                 numReplicas,
-		StorageBackend:           "couchstore",
-		Type:                     "couchbase",
+		StorageBackend:           storageBackend,
+		Type:                     capellaBucketType,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create bucket")
 	}
 
 	return nil
+}
+
+// capellaBucketParams maps a deployment bucket type onto the Capella bucket
+// "type" and storage backend values. Memcached buckets are not offered by
+// Capella, so they are rejected explicitly rather than sent as an invalid
+// request. An empty bucket type defaults to couchbase.
+func capellaBucketParams(bucketType deployment.BucketType) (capellaType string, storageBackend string, err error) {
+	if bucketType == "" {
+		bucketType = deployment.BucketTypeCouchbase
+	}
+
+	switch bucketType {
+	case deployment.BucketTypeCouchbase:
+		return "couchbase", "couchstore", nil
+	case deployment.BucketTypeEphemeral:
+		// Ephemeral buckets are memory-only and reject a disk storage
+		// backend, so leave it empty (omitted from the request).
+		return "ephemeral", "", nil
+	case deployment.BucketTypeMemcached:
+		return "", "", errors.New("memcached buckets are not supported by the cloud deployer")
+	default:
+		return "", "", errors.Errorf("unsupported bucket type %q", bucketType)
+	}
 }
 
 func (p *Deployer) DeleteBucket(ctx context.Context, clusterID string, bucketName string) error {

--- a/deployment/commondeploy/agenthelper.go
+++ b/deployment/commondeploy/agenthelper.go
@@ -33,29 +33,12 @@ func (h AgentHelper) ListBuckets(ctx context.Context) ([]deployment.BucketInfo, 
 }
 
 func (h AgentHelper) CreateBucket(ctx context.Context, opts *deployment.CreateBucketOptions) error {
-	ramQuotaMb := 256
-	if opts.RamQuotaMB > 0 {
-		ramQuotaMb = opts.RamQuotaMB
+	createOpts, err := buildMgmtxCreateBucketOptions(opts)
+	if err != nil {
+		return err
 	}
 
-	err := h.Agent.CreateBucket(ctx, &cbmgmtx.CreateBucketOptions{
-		BucketName: opts.Name,
-		BucketSettings: cbmgmtx.BucketSettings{
-			BucketType:             "membase",
-			StorageBackend:         "couchstore",
-			ReplicaIndex:           false,
-			ConflictResolutionType: "seqno",
-			MutableBucketSettings: cbmgmtx.MutableBucketSettings{
-				EvictionPolicy:     "valueOnly",
-				ReplicaNumber:      uint32(opts.NumReplicas),
-				DurabilityMinLevel: "none",
-				CompressionMode:    "",
-				MaxTTL:             0,
-				RAMQuotaMB:         uint64(ramQuotaMb),
-				FlushEnabled:       opts.FlushEnabled,
-			},
-		},
-	})
+	err = h.Agent.CreateBucket(ctx, createOpts)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			return fmt.Errorf("%w: %s", deployment.ErrBucketAlreadyExists, err.Error())

--- a/deployment/commondeploy/buckets.go
+++ b/deployment/commondeploy/buckets.go
@@ -1,0 +1,85 @@
+package commondeploy
+
+import (
+	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/pkg/errors"
+)
+
+// defaultBucketRAMQuotaMB is used when the caller does not request a specific
+// RAM quota for the bucket.
+const defaultBucketRAMQuotaMB = 256
+
+// buildMgmtxCreateBucketOptions translates the deployment-level bucket creation
+// options into the cbmgmtx settings used against a live server, applying the
+// per-bucket-type rules that Couchbase Server enforces:
+//
+//   - couchbase ("membase"): persistent, couchstore storage backend, valueOnly
+//     eviction.
+//   - ephemeral: memory-only, so no disk storage backend may be specified and
+//     only the noEviction/nruEviction policies are valid.
+//   - memcached: a legacy, flat in-memory cache with no replicas, no conflict
+//     resolution, no durability, no eviction policy and no storage backend.
+//     Couchbase Server 8.0+ rejects this type outright ("memcached buckets are
+//     no longer supported"); it is only creatable on older clusters.
+//
+// It returns an error for an unrecognized bucket type rather than silently
+// falling back to a couchbase bucket, so an invalid type that bypassed
+// ParseBucketType (e.g. a directly-constructed CreateBucketOptions) fails
+// closed.
+func buildMgmtxCreateBucketOptions(opts *deployment.CreateBucketOptions) (*cbmgmtx.CreateBucketOptions, error) {
+	ramQuotaMB := defaultBucketRAMQuotaMB
+	if opts.RamQuotaMB > 0 {
+		ramQuotaMB = opts.RamQuotaMB
+	}
+
+	bucketType := opts.BucketType
+	if bucketType == "" {
+		bucketType = deployment.BucketTypeCouchbase
+	}
+
+	settings := cbmgmtx.BucketSettings{
+		ConflictResolutionType: cbmgmtx.ConflictResolutionTypeSequenceNumber,
+		ReplicaIndex:           false,
+		MutableBucketSettings: cbmgmtx.MutableBucketSettings{
+			ReplicaNumber:      uint32(opts.NumReplicas),
+			DurabilityMinLevel: cbmgmtx.DurabilityLevelNone,
+			RAMQuotaMB:         uint64(ramQuotaMB),
+			FlushEnabled:       opts.FlushEnabled,
+		},
+	}
+
+	switch bucketType {
+	case deployment.BucketTypeCouchbase:
+		settings.BucketType = cbmgmtx.BucketTypeCouchbase
+		settings.StorageBackend = cbmgmtx.StorageBackendCouchstore
+		settings.EvictionPolicy = cbmgmtx.EvictionPolicyTypeValueOnly
+	case deployment.BucketTypeEphemeral:
+		settings.BucketType = cbmgmtx.BucketTypeEphemeral
+		// Ephemeral buckets keep no data on disk; the server rejects a
+		// storage backend and only accepts the noEviction/nruEviction
+		// policies, so leave the storage backend unset and default to
+		// noEviction.
+		settings.EvictionPolicy = cbmgmtx.EvictionPolicyTypeNoEviction
+	case deployment.BucketTypeMemcached:
+		settings.BucketType = cbmgmtx.BucketTypeMemcached
+		// Memcached buckets are a legacy, flat in-memory cache: they support
+		// no replicas, no conflict resolution, no durability, no eviction
+		// policy and no storage backend. Explicitly clear every setting an
+		// (older) server would reject for memcached rather than relying on a
+		// switch fall-through, so the intent is local and refactor-safe.
+		// Couchbase Server 8.0+ rejects this type regardless of these settings.
+		settings.ReplicaNumber = 0
+		settings.ConflictResolutionType = cbmgmtx.ConflictResolutionTypeUnset
+		settings.DurabilityMinLevel = cbmgmtx.DurabilityLevelUnset
+		settings.EvictionPolicy = cbmgmtx.EvictionPolicyTypeUnset
+		settings.StorageBackend = cbmgmtx.StorageBackendUnset
+	default:
+		return nil, errors.Errorf("unsupported bucket type %q", bucketType)
+	}
+
+	return &cbmgmtx.CreateBucketOptions{
+		BucketName:     opts.Name,
+		BucketSettings: settings,
+	}, nil
+}

--- a/deployment/commondeploy/buckets_test.go
+++ b/deployment/commondeploy/buckets_test.go
@@ -1,0 +1,111 @@
+package commondeploy
+
+import (
+	"testing"
+
+	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMgmtxCreateBucketOptionsCouchbase(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name:         "default",
+		BucketType:   deployment.BucketTypeCouchbase,
+		RamQuotaMB:   512,
+		FlushEnabled: true,
+		NumReplicas:  2,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "default", got.BucketName)
+	require.Equal(t, cbmgmtx.BucketTypeCouchbase, got.BucketSettings.BucketType)
+	require.Equal(t, cbmgmtx.StorageBackendCouchstore, got.BucketSettings.StorageBackend)
+	require.Equal(t, cbmgmtx.EvictionPolicyTypeValueOnly, got.BucketSettings.EvictionPolicy)
+	require.Equal(t, cbmgmtx.ConflictResolutionTypeSequenceNumber, got.BucketSettings.ConflictResolutionType)
+	require.False(t, got.BucketSettings.ReplicaIndex)
+	require.Equal(t, uint32(2), got.BucketSettings.ReplicaNumber)
+	require.Equal(t, uint64(512), got.BucketSettings.RAMQuotaMB)
+	require.True(t, got.BucketSettings.FlushEnabled)
+}
+
+func TestBuildMgmtxCreateBucketOptionsEmptyTypeDefaultsToCouchbase(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name: "default",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, cbmgmtx.BucketTypeCouchbase, got.BucketSettings.BucketType)
+	require.Equal(t, cbmgmtx.StorageBackendCouchstore, got.BucketSettings.StorageBackend)
+	require.Equal(t, cbmgmtx.EvictionPolicyTypeValueOnly, got.BucketSettings.EvictionPolicy)
+}
+
+func TestBuildMgmtxCreateBucketOptionsDefaultRAMQuota(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name: "default",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(defaultBucketRAMQuotaMB), got.BucketSettings.RAMQuotaMB)
+}
+
+func TestBuildMgmtxCreateBucketOptionsEphemeral(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name:        "events",
+		BucketType:  deployment.BucketTypeEphemeral,
+		NumReplicas: 1,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, cbmgmtx.BucketTypeEphemeral, got.BucketSettings.BucketType)
+	// Ephemeral buckets are memory-only: no disk storage backend may be set,
+	// and only noEviction/nruEviction are valid eviction policies.
+	require.Equal(t, cbmgmtx.StorageBackendUnset, got.BucketSettings.StorageBackend)
+	require.Equal(t, cbmgmtx.EvictionPolicyTypeNoEviction, got.BucketSettings.EvictionPolicy)
+	require.False(t, got.BucketSettings.ReplicaIndex)
+	require.Equal(t, uint32(1), got.BucketSettings.ReplicaNumber)
+}
+
+func TestBuildMgmtxCreateBucketOptionsMemcached(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name:        "cache",
+		BucketType:  deployment.BucketTypeMemcached,
+		NumReplicas: 2,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, cbmgmtx.BucketTypeMemcached, got.BucketSettings.BucketType)
+	// Memcached buckets are a flat in-memory cache: no replicas, no conflict
+	// resolution, no durability, no eviction policy and no storage backend.
+	// Every one of these must be left unset so the encoder omits it from the
+	// request the server would otherwise reject.
+	require.Equal(t, uint32(0), got.BucketSettings.ReplicaNumber)
+	require.Equal(t, cbmgmtx.ConflictResolutionTypeUnset, got.BucketSettings.ConflictResolutionType)
+	require.Equal(t, cbmgmtx.DurabilityLevelUnset, got.BucketSettings.DurabilityMinLevel)
+	require.Equal(t, cbmgmtx.EvictionPolicyTypeUnset, got.BucketSettings.EvictionPolicy)
+	require.Equal(t, cbmgmtx.StorageBackendUnset, got.BucketSettings.StorageBackend)
+}
+
+func TestBuildMgmtxCreateBucketOptionsUnsupportedTypeErrors(t *testing.T) {
+	got, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+		Name:       "broken",
+		BucketType: deployment.BucketType("nonsense"),
+	})
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+// TestBuildMgmtxCreateBucketOptionsHandlesAllTypes is a drift guard: every
+// bucket type in deployment.AllBucketTypes must be handled by the builder
+// without hitting the unsupported-type error path.
+func TestBuildMgmtxCreateBucketOptionsHandlesAllTypes(t *testing.T) {
+	for _, bt := range deployment.AllBucketTypes {
+		t.Run(string(bt), func(t *testing.T) {
+			_, err := buildMgmtxCreateBucketOptions(&deployment.CreateBucketOptions{
+				Name:       "b",
+				BucketType: bt,
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/deployment/commondeploy/mgmtxhelper.go
+++ b/deployment/commondeploy/mgmtxhelper.go
@@ -31,29 +31,12 @@ func (h MgmtxHelper) ListBuckets(ctx context.Context) ([]deployment.BucketInfo, 
 }
 
 func (h MgmtxHelper) CreateBucket(ctx context.Context, opts *deployment.CreateBucketOptions) error {
-	ramQuotaMb := 256
-	if opts.RamQuotaMB > 0 {
-		ramQuotaMb = opts.RamQuotaMB
+	createOpts, err := buildMgmtxCreateBucketOptions(opts)
+	if err != nil {
+		return err
 	}
 
-	err := h.Mgmt.CreateBucket(ctx, &cbmgmtx.CreateBucketOptions{
-		BucketName: opts.Name,
-		BucketSettings: cbmgmtx.BucketSettings{
-			BucketType:             "membase",
-			StorageBackend:         "couchstore",
-			ReplicaIndex:           false,
-			ConflictResolutionType: "seqno",
-			MutableBucketSettings: cbmgmtx.MutableBucketSettings{
-				EvictionPolicy:     "valueOnly",
-				ReplicaNumber:      uint32(opts.NumReplicas),
-				DurabilityMinLevel: "none",
-				CompressionMode:    "",
-				MaxTTL:             0,
-				RAMQuotaMB:         uint64(ramQuotaMb),
-				FlushEnabled:       opts.FlushEnabled,
-			},
-		},
-	})
+	err = h.Mgmt.CreateBucket(ctx, createOpts)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			return fmt.Errorf("%w: %s", deployment.ErrBucketAlreadyExists, err.Error())

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -64,6 +64,7 @@ type BucketInfo struct {
 
 type CreateBucketOptions struct {
 	Name         string
+	BucketType   BucketType
 	RamQuotaMB   int
 	FlushEnabled bool
 	NumReplicas  int

--- a/examples/buckets-scope-collection.yaml
+++ b/examples/buckets-scope-collection.yaml
@@ -4,6 +4,9 @@ nodes:
 buckets:
   app-data:
     settings:
+      # bucket-type may be couchbase (default) or ephemeral. memcached is a
+      # legacy type that Couchbase Server 8.0+ rejects (older clusters only).
+      bucket-type: couchbase
       ram-quota-mb: 512
       flush-enabled: true
       num-replicas: 1

--- a/utils/capellacontrol/controller.go
+++ b/utils/capellacontrol/controller.go
@@ -1624,7 +1624,7 @@ type CreateBucketRequest struct {
 	MemoryAllocationInMB     int    `json:"memoryAllocationInMb"`
 	Name                     string `json:"name"`
 	Replicas                 int    `json:"replicas"`
-	StorageBackend           string `json:"storageBackend"`
+	StorageBackend           string `json:"storageBackend,omitempty"`
 	// timeToLive
 	Type string `json:"type"`
 }


### PR DESCRIPTION
Previously every bucket was created as a couchbase ("membase") bucket, with the type hardcoded deep in the deployment helpers. Add a `--bucket-type` flag (and a matching `bucket-type` setting in the YAML cluster definition) accepting `couchbase` (default), `ephemeral`, and `memcached`.

The per-type settings are derived centrally so each backend stays within what Couchbase Server accepts:

  - ephemeral: no disk storage backend, defaults to the noEviction policy
  - memcached: no replicas, conflict resolution, durability or eviction

memcached is a legacy type: Couchbase Server 8.0 and later reject it outright ("memcached buckets are no longer supported"), so it is only creatable on older clusters. The settings above describe how the option behaves where the type is still accepted.

The duplicated bucket-settings block in the agent and mgmtx helpers is replaced by a single `buildMgmtxCreateBucketOptions` builder that fails closed on an unknown type, and the Capella path gains a `capellaBucketParams` mapper that rejects memcached (unsupported on Capella) and omits the storage backend for ephemeral. Bucket types are validated up front in `allocate`, before the cluster is provisioned.