### PR TITLE
Add DNS suffix to certs for nodes added after allocation

### DIFF
--- a/deployment/dockerdeploy/deployer_newaddremove.go
+++ b/deployment/dockerdeploy/deployer_newaddremove.go
@@ -642,8 +642,10 @@ func (d *Deployer) addRemoveNodes(
 			Image:              image,
 			ImageServerVersion: nodeGrp.Version,
 			IsColumnar:         clusterInfo.IsColumnar(),
+			DnsSuffix:          clusterInfo.DnsName,
 			Expiry:             time.Until(clusterInfo.Expiry),
 			EnvVars:            nodeGrp.Docker.EnvVars,
+			UseDinoCerts:       clusterInfo.UsingDinoCerts,
 		}
 
 		d.logger.Info("deploying node", zap.Any("deployOpts", deployOpts))


### PR DESCRIPTION
Motivation
----------
When scaling a DNS-load-balanced cluster, nodes added after initial allocation received TLS certs with only an IP SAN, missing the cluster DNS name. Requests routed to those nodes failed hostname verification (altname mismatch).

Changes
-------
* Pass DnsSuffix and UseDinoCerts into DeployNodeOptions in addRemoveNodes (deployment/dockerdeploy/deployer_newaddremove.go) so added nodes' certs include the cluster DNS name as a SAN.