### PR TITLE
SDKQE-3987: Reduce capella v4 call volume

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/couchbaselabs/cbdinocluster/utils/azurecontrol"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -17,7 +18,8 @@ type cleanableTarget interface {
 
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup [flags] [deployer-name]",
-	Short: "Cleans up any expired resources for a deployer",
+	Short: "Cleans up any expired resources for a deployer, or for every deployer",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
@@ -86,6 +88,11 @@ var cleanupCmd = &cobra.Command{
 		if len(args) >= 1 {
 			selectedCleaner := args[0]
 			cleaner := cleaners[selectedCleaner]
+			if cleaner == nil {
+				logger.Fatal("the specified deployer is not available",
+					zap.String("deployer", selectedCleaner),
+					zap.Strings("available", maps.Keys(cleaners)))
+			}
 			cleaners = map[string]cleanableTarget{
 				selectedCleaner: cleaner,
 			}
@@ -114,6 +121,8 @@ var cleanupCmd = &cobra.Command{
 		logger.Info("identified cleaners and order",
 			zap.Strings("cleaners", finalCleanupOrder))
 
+		// Keep sweeping the other deployers, then report.
+		failed := false
 		for _, cleanerName := range finalCleanupOrder {
 			cleaner := cleaners[cleanerName]
 
@@ -122,8 +131,14 @@ var cleanupCmd = &cobra.Command{
 
 			err := cleaner.Cleanup(ctx)
 			if err != nil {
-				logger.Fatal("failed to cleanup resources", zap.Error(err))
+				failed = true
+				logger.Error("failed to cleanup resources",
+					zap.String("cleaner", cleanerName), zap.Error(err))
 			}
+		}
+
+		if failed {
+			logger.Fatal("one or more cleaners failed")
 		}
 	},
 }

--- a/cmd/cmdhelper.go
+++ b/cmd/cmdhelper.go
@@ -505,7 +505,9 @@ func (h *CmdHelper) IdentifyCluster(ctx context.Context, userInput string) (stri
 	for deployerName, deployer := range allDeployers {
 		wg.Add(1)
 		go func(deployerName string, deployer deployment.Deployer) {
-			clusters, err := deployer.ListClusters(cancelCtx)
+			defer wg.Done()
+
+			clusters, err := deployer.FindClusters(cancelCtx, userInput)
 			if err != nil {
 				// ignore errors if the context is cancelled
 				if cancelCtx.Err() != nil {
@@ -522,16 +524,12 @@ func (h *CmdHelper) IdentifyCluster(ctx context.Context, userInput string) (stri
 				zap.String("deployer", deployerName))
 
 			for _, cluster := range clusters {
-				if strings.HasPrefix(cluster.GetID(), userInput) {
-					identifiedCluster <- &clusterWithDeployer{
-						DeployerName: deployerName,
-						Deployer:     deployer,
-						Cluster:      cluster,
-					}
+				identifiedCluster <- &clusterWithDeployer{
+					DeployerName: deployerName,
+					Deployer:     deployer,
+					Cluster:      cluster,
 				}
 			}
-
-			wg.Done()
 		}(deployerName, deployer)
 	}
 	go func() {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/couchbaselabs/cbdinocluster/deployment"
+	"github.com/couchbaselabs/cbdinocluster/deployment/clouddeploy"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -21,9 +22,14 @@ type ClusterListOutput_Item struct {
 	ID       string                   `json:"id"`
 	Type     string                   `json:"type"`
 	State    string                   `json:"state"`
+	Purpose  string                   `json:"purpose,omitempty"`
 	Expiry   *time.Time               `json:"expiry,omitempty"`
 	Deployer string                   `json:"deployer"`
 	Nodes    []ClusterListOutput_Node `json:"nodes"`
+
+	// Capella only. Used to find the cluster in the Capella UI.
+	CloudProjectID string `json:"cloud_project_id,omitempty"`
+	CloudClusterID string `json:"cloud_cluster_id,omitempty"`
 }
 
 type ClusterListOutput_Node struct {
@@ -35,9 +41,10 @@ type ClusterListOutput_Node struct {
 }
 
 var listCmd = &cobra.Command{
-	Use:     "list",
+	Use:     "list [cluster-id]",
 	Aliases: []string{"ls", "ps"},
-	Short:   "Lists all clusters",
+	Short:   "Lists all clusters, or only those matching an optional cluster id prefix",
+	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		helper := CmdHelper{}
 		logger := helper.GetLogger()
@@ -52,7 +59,13 @@ var listCmd = &cobra.Command{
 		for deployerName, deployer := range deployers {
 			wg.Add(1)
 			go func(deployerName string, deployer deployment.Deployer) {
-				deployerClusters, err := deployer.ListClusters(ctx)
+				var deployerClusters []deployment.ClusterInfo
+				var err error
+				if len(args) == 1 {
+					deployerClusters, err = deployer.FindClusters(ctx, args[0])
+				} else {
+					deployerClusters, err = deployer.ListClusters(ctx)
+				}
 				if err != nil {
 					logger.Warn("failed to list clusters", zap.Error(err))
 				}
@@ -90,12 +103,18 @@ var listCmd = &cobra.Command{
 					expiryStr = time.Until(cluster.GetExpiry()).Round(time.Second).String()
 				}
 
-				fmt.Printf("  %s [Type: %s, State: %s, Timeout: %s, Deployer: %s]\n",
+				purposeStr := ""
+				if purpose := cluster.GetPurpose(); purpose != "" {
+					purposeStr = fmt.Sprintf(", Purpose: %s", purpose)
+				}
+
+				fmt.Printf("  %s [Type: %s, State: %s, Timeout: %s, Deployer: %s%s]\n",
 					cluster.GetID(),
 					cluster.GetType(),
 					cluster.GetState(),
 					expiryStr,
-					deployerName)
+					deployerName,
+					purposeStr)
 				for _, node := range cluster.GetNodes() {
 					printId := node.GetID()
 					if !node.IsClusterNode() {
@@ -116,7 +135,13 @@ var listCmd = &cobra.Command{
 					ID:       cluster.Info.GetID(),
 					Type:     string(cluster.Info.GetType()),
 					State:    cluster.Info.GetState(),
+					Purpose:  cluster.Info.GetPurpose(),
 					Deployer: cluster.DeployerName,
+				}
+
+				if cloudInfo, ok := cluster.Info.(*clouddeploy.ClusterInfo); ok {
+					clusterItem.CloudProjectID = cloudInfo.CloudProjectID
+					clusterItem.CloudClusterID = cloudInfo.CloudClusterID
 				}
 
 				expiry := cluster.Info.GetExpiry()

--- a/deployment/caodeploy/deployer.go
+++ b/deployment/caodeploy/deployer.go
@@ -247,6 +247,15 @@ func (d *Deployer) ListClusters(ctx context.Context) ([]deployment.ClusterInfo, 
 	return clusters, nil
 }
 
+func (d *Deployer) FindClusters(ctx context.Context, idPrefix string) ([]deployment.ClusterInfo, error) {
+	clusters, err := d.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployment.FilterClustersByPrefix(clusters, idPrefix), nil
+}
+
 func (d *Deployer) generateClusterSpec(
 	ctx context.Context,
 	def *clusterdef.Cluster,

--- a/deployment/clouddeploy/clusterinfo.go
+++ b/deployment/clouddeploy/clusterinfo.go
@@ -8,6 +8,7 @@ import (
 
 type ClusterInfo struct {
 	ClusterID      string
+	Purpose        string
 	Type           deployment.ClusterType
 	CloudProjectID string
 	CloudClusterID string
@@ -21,7 +22,7 @@ var _ (deployment.ClusterInfo) = (*ClusterInfo)(nil)
 
 func (i ClusterInfo) GetID() string                   { return i.ClusterID }
 func (i ClusterInfo) GetType() deployment.ClusterType { return i.Type }
-func (i ClusterInfo) GetPurpose() string              { return "" }
+func (i ClusterInfo) GetPurpose() string              { return i.Purpose }
 func (i ClusterInfo) GetExpiry() time.Time            { return i.Expiry }
 func (i ClusterInfo) GetState() string                { return i.State }
 func (i ClusterInfo) GetNodes() []deployment.ClusterNodeInfo {

--- a/deployment/clouddeploy/deployer.go
+++ b/deployment/clouddeploy/deployer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/multierr"
@@ -127,6 +128,27 @@ type cbdc2Project struct {
 	Info *capellav4.ProjectInfo
 }
 
+const maxProjectInspectConcurrency = 8
+
+// maxProjectNameLen is the limit the v4 api puts on a project name.
+const maxProjectNameLen = 128
+
+// projectNameFor encodes the cluster identity into the project name. A long
+// purpose is trimmed so the create cannot fail on length.
+func (p *Deployer) projectNameFor(meta stringclustermeta.MetaData) string {
+	name := meta.String()
+	if len(name) <= maxProjectNameLen {
+		return name
+	}
+
+	overflow := len(name) - maxProjectNameLen
+	meta.Purpose = meta.Purpose[:len(meta.Purpose)-overflow]
+	p.logger.Warn("trimmed the purpose to fit the project name limit",
+		zap.String("purpose", meta.Purpose))
+
+	return meta.String()
+}
+
 func (p *Deployer) listCbdc2Projects(ctx context.Context) ([]cbdc2Project, error) {
 	p.logger.Debug("listing cloud projects")
 
@@ -157,54 +179,123 @@ func (p *Deployer) listCbdc2Projects(ctx context.Context) ([]cbdc2Project, error
 }
 
 func (p *Deployer) inspectProject(ctx context.Context, project cbdc2Project) (*clusterInfo, error) {
+	projectID := project.Info.ID
+
 	base := &clusterInfo{
 		Meta:        project.Meta,
-		ProjectID:   project.Info.ID,
+		ProjectID:   projectID,
 		ProjectName: project.Info.Name,
 	}
 
-	clusters, err := p.v4.ListClusters(ctx, p.tenantID, project.Info.ID)
+	clusters, err := p.v4.ListClusters(ctx, p.tenantID, projectID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list clusters for project")
 	}
 
-	columnars, err := p.v4.ListAnalyticsClusters(ctx, p.tenantID, project.Info.ID)
+	// The org wide analytics listing carries no project, so ask per project.
+	projectColumnars, err := p.v4.ListAnalyticsClusters(ctx, p.tenantID, projectID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list analytics clusters for project")
 	}
 
-	if len(clusters)+len(columnars) > 1 {
+	if len(clusters)+len(projectColumnars) > 1 {
 		base.IsCorrupted = true
 		return base, nil
 	}
 	if len(clusters) == 1 {
 		base.Cluster = clusters[0]
-	} else if len(columnars) == 1 {
-		base.Columnar = columnars[0]
+	} else if len(projectColumnars) == 1 {
+		base.Columnar = projectColumnars[0]
 	}
 
 	return base, nil
 }
 
-func (p *Deployer) listClusters(ctx context.Context) ([]*clusterInfo, error) {
+// findClusters inspects only the cbdc2 projects whose cluster ID matches, so a
+// single lookup costs one project listing instead of one per project.
+func (p *Deployer) findClusters(ctx context.Context, idPrefix string) ([]*clusterInfo, error) {
 	projects, err := p.listCbdc2Projects(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	p.logger.Debug("listing cloud clusters", zap.Int("projects", len(projects)))
-
-	var out []*clusterInfo
+	var matched []cbdc2Project
 	for _, project := range projects {
-		info, err := p.inspectProject(ctx, project)
+		if strings.HasPrefix(project.Meta.ID.String(), idPrefix) {
+			matched = append(matched, project)
+		}
+	}
+
+	p.logger.Debug("listing cloud clusters",
+		zap.Int("projects", len(projects)),
+		zap.Int("matched-projects", len(matched)))
+
+	if len(matched) == 0 {
+		return nil, nil
+	}
+
+	if len(matched) == 1 {
+		info, err := p.inspectProject(ctx, matched[0])
 		if err != nil {
 			return nil, err
 		}
 
-		out = append(out, info)
+		return []*clusterInfo{info}, nil
+	}
+
+	inspectCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var errOnce sync.Once
+	var firstErr error
+
+	results := make([]*clusterInfo, len(matched))
+	sem := make(chan struct{}, maxProjectInspectConcurrency)
+
+	for i, project := range matched {
+		wg.Add(1)
+		go func(i int, project cbdc2Project) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if inspectCtx.Err() != nil {
+				return
+			}
+
+			info, err := p.inspectProject(inspectCtx, project)
+			if err != nil {
+				errOnce.Do(func() {
+					firstErr = err
+					cancel()
+				})
+				return
+			}
+
+			results[i] = info
+		}(i, project)
+	}
+
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	var out []*clusterInfo
+	for _, info := range results {
+		if info != nil {
+			out = append(out, info)
+		}
 	}
 
 	return out, nil
+}
+
+func (p *Deployer) listClusters(ctx context.Context) ([]*clusterInfo, error) {
+	return p.findClusters(ctx, "")
 }
 
 func (p *Deployer) getCluster(ctx context.Context, clusterID string) (*clusterInfo, error) {
@@ -273,64 +364,75 @@ func (p *Deployer) columnarV2DetailByID(ctx context.Context, columnarID string) 
 	return nil, errors.New("failed to find columnar instance")
 }
 
+func (p *Deployer) toClusterInfo(cluster *clusterInfo) *ClusterInfo {
+	if cluster.IsCorrupted {
+		return &ClusterInfo{
+			ClusterID:      cluster.Meta.ID.String(),
+			Purpose:        cluster.Meta.Purpose,
+			Type:           deployment.ClusterTypeUnknown,
+			CloudProjectID: cluster.ProjectID,
+			CloudClusterID: "",
+			CloudProvider:  "",
+			Region:         "",
+			Expiry:         cluster.Meta.Expiry,
+			State:          "corrupted",
+		}
+	}
+
+	if cluster.Cluster == nil && cluster.Columnar == nil {
+		return &ClusterInfo{
+			ClusterID:      cluster.Meta.ID.String(),
+			Purpose:        cluster.Meta.Purpose,
+			Type:           deployment.ClusterTypeUnknown,
+			CloudProjectID: cluster.ProjectID,
+			CloudClusterID: "",
+			CloudProvider:  "",
+			Region:         "",
+			Expiry:         cluster.Meta.Expiry,
+			State:          "provisioning",
+		}
+	}
+
+	if cluster.Cluster != nil {
+		return &ClusterInfo{
+			ClusterID:      cluster.Meta.ID.String(),
+			Purpose:        cluster.Meta.Purpose,
+			Type:           deployment.ClusterTypeServer,
+			CloudProjectID: cluster.ProjectID,
+			CloudClusterID: cluster.Cluster.ID,
+			CloudProvider:  cluster.Cluster.CloudProvider.Type,
+			Region:         cluster.Cluster.CloudProvider.Region,
+			Expiry:         cluster.Meta.Expiry,
+			State:          cluster.Cluster.CurrentState,
+		}
+	}
+
+	return &ClusterInfo{
+		ClusterID:      cluster.Meta.ID.String(),
+		Purpose:        cluster.Meta.Purpose,
+		Type:           deployment.ClusterTypeColumnar,
+		CloudProjectID: cluster.ProjectID,
+		CloudClusterID: cluster.Columnar.ID,
+		CloudProvider:  cluster.Columnar.CloudProviderName(),
+		Region:         cluster.Columnar.Region,
+		Expiry:         cluster.Meta.Expiry,
+		State:          cluster.Columnar.CurrentState,
+	}
+}
+
 func (p *Deployer) ListClusters(ctx context.Context) ([]deployment.ClusterInfo, error) {
-	clusters, err := p.listClusters(ctx)
+	return p.FindClusters(ctx, "")
+}
+
+func (p *Deployer) FindClusters(ctx context.Context, idPrefix string) ([]deployment.ClusterInfo, error) {
+	clusters, err := p.findClusters(ctx, idPrefix)
 	if err != nil {
 		return nil, err
 	}
 
 	var out []deployment.ClusterInfo
-
 	for _, cluster := range clusters {
-		if cluster.IsCorrupted {
-			out = append(out, &ClusterInfo{
-				ClusterID:      cluster.Meta.ID.String(),
-				Type:           deployment.ClusterTypeUnknown,
-				CloudProjectID: cluster.ProjectID,
-				CloudClusterID: "",
-				CloudProvider:  "",
-				Region:         "",
-				Expiry:         cluster.Meta.Expiry,
-				State:          "corrupted",
-			})
-			continue
-		} else if cluster.Cluster == nil && cluster.Columnar == nil {
-			out = append(out, &ClusterInfo{
-				ClusterID:      cluster.Meta.ID.String(),
-				Type:           deployment.ClusterTypeUnknown,
-				CloudProjectID: cluster.ProjectID,
-				CloudClusterID: "",
-				CloudProvider:  "",
-				Region:         "",
-				Expiry:         cluster.Meta.Expiry,
-				State:          "provisioning",
-			})
-			continue
-		}
-
-		if cluster.Cluster != nil {
-			out = append(out, &ClusterInfo{
-				ClusterID:      cluster.Meta.ID.String(),
-				Type:           deployment.ClusterTypeServer,
-				CloudProjectID: cluster.ProjectID,
-				CloudClusterID: cluster.Cluster.ID,
-				CloudProvider:  cluster.Cluster.CloudProvider.Type,
-				Region:         cluster.Cluster.CloudProvider.Region,
-				Expiry:         cluster.Meta.Expiry,
-				State:          cluster.Cluster.CurrentState,
-			})
-		} else if cluster.Columnar != nil {
-			out = append(out, &ClusterInfo{
-				ClusterID:      cluster.Meta.ID.String(),
-				Type:           deployment.ClusterTypeColumnar,
-				CloudProjectID: cluster.ProjectID,
-				CloudClusterID: cluster.Columnar.ID,
-				CloudProvider:  cluster.Columnar.CloudProviderName(),
-				Region:         cluster.Columnar.Region,
-				Expiry:         cluster.Meta.Expiry,
-				State:          cluster.Columnar.CurrentState,
-			})
-		}
+		out = append(out, p.toClusterInfo(cluster))
 	}
 
 	return out, nil
@@ -474,10 +576,11 @@ func (p *Deployer) deployNewCluster(ctx context.Context, def *clusterdef.Cluster
 	}
 
 	metaData := stringclustermeta.MetaData{
-		ID:     clusterID,
-		Expiry: expiryTime,
+		ID:      clusterID,
+		Expiry:  expiryTime,
+		Purpose: def.Purpose,
 	}
-	projectName := metaData.String()
+	projectName := p.projectNameFor(metaData)
 
 	p.logger.Debug("creating a new cloud project")
 
@@ -576,25 +679,18 @@ func (p *Deployer) deployNewCluster(ctx context.Context, def *clusterdef.Cluster
 		return nil, errors.Wrap(err, "failed to wait for cluster deployment")
 	}
 
-	// we cheat for now...
-	clusters, err := p.ListClusters(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list clusters")
-	}
-
-	var thisCluster *ClusterInfo
-	for _, cluster := range clusters {
-		cluster := cluster.(*ClusterInfo)
-
-		if cluster.ClusterID == clusterID.String() {
-			thisCluster = cluster
-		}
-	}
-	if thisCluster == nil {
-		return nil, errors.New("failed to find new cluster after deployment")
-	}
-
-	return thisCluster, nil
+	// The deployment already waited for the healthy state, so a read back adds nothing.
+	return &ClusterInfo{
+		ClusterID:      clusterID.String(),
+		Purpose:        metaData.Purpose,
+		Type:           deployment.ClusterTypeServer,
+		CloudProjectID: cloudProjectID,
+		CloudClusterID: cloudClusterID,
+		CloudProvider:  cloudProvider,
+		Region:         cloudRegion,
+		Expiry:         metaData.Expiry,
+		State:          capellav4.StateHealthy,
+	}, nil
 }
 
 func (p *Deployer) resolveCloudLocation(def *clusterdef.Cluster) (string, string, error) {
@@ -629,10 +725,11 @@ func (p *Deployer) createNewCluster(ctx context.Context, def *clusterdef.Cluster
 	}
 
 	metaData := stringclustermeta.MetaData{
-		ID:     clusterID,
-		Expiry: expiryTime,
+		ID:      clusterID,
+		Expiry:  expiryTime,
+		Purpose: def.Purpose,
 	}
-	projectName := metaData.String()
+	projectName := p.projectNameFor(metaData)
 
 	cloudProvider, cloudRegion, err := p.resolveCloudLocation(def)
 	if err != nil {
@@ -799,24 +896,23 @@ func (p *Deployer) createNewCluster(ctx context.Context, def *clusterdef.Cluster
 		}
 	}
 
-	// we cheat for now...
-	clusters, err := p.ListClusters(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list clusters")
+	clusterType := deployment.ClusterTypeServer
+	if def.Columnar {
+		clusterType = deployment.ClusterTypeColumnar
 	}
 
-	var thisCluster *ClusterInfo
-	for _, cluster := range clusters {
-		cluster := cluster.(*ClusterInfo)
-
-		if cluster.ClusterID == clusterID.String() {
-			thisCluster = cluster
-		}
-	}
-	if thisCluster == nil {
-		return nil, errors.New("failed to find new cluster after deployment")
-	}
-	return thisCluster, nil
+	// Every branch above waited for the healthy state, so a read back adds nothing.
+	return &ClusterInfo{
+		ClusterID:      clusterID.String(),
+		Purpose:        metaData.Purpose,
+		Type:           clusterType,
+		CloudProjectID: cloudProjectID,
+		CloudClusterID: cloudClusterID,
+		CloudProvider:  cloudProvider,
+		Region:         cloudRegion,
+		Expiry:         metaData.Expiry,
+		State:          capellav4.StateHealthy,
+	}, nil
 }
 
 func (p *Deployer) NewCluster(ctx context.Context, def *clusterdef.Cluster) (deployment.ClusterInfo, error) {
@@ -1671,7 +1767,15 @@ func (p *Deployer) Cleanup(ctx context.Context) error {
 	curTime := time.Now()
 	var allErr error
 	for _, cluster := range clusters {
+		expired := !cluster.Meta.Expiry.IsZero() && !cluster.Meta.Expiry.After(curTime)
+
+		// An allocate creates the project first, so an unexpired empty project may
+		// belong to a run still in flight.
 		if cluster.Cluster == nil && cluster.Columnar == nil && !cluster.IsCorrupted {
+			if !expired {
+				continue
+			}
+
 			p.logger.Info("removing empty project",
 				zap.String("project-id", cluster.ProjectID))
 
@@ -1682,18 +1786,23 @@ func (p *Deployer) Cleanup(ctx context.Context) error {
 			continue
 		}
 
-		if !cluster.Meta.Expiry.IsZero() && !cluster.Meta.Expiry.After(curTime) {
-			p.logger.Info("removing cluster",
-				zap.String("cluster-id", cluster.Meta.ID.String()))
-
+		if expired {
+			// Capella itself failed to destroy these, so asking again does nothing.
 			if cluster.Cluster != nil && cluster.Cluster.CurrentState == capellav4.StateDestroyFailed {
-				p.logger.Warn("skipping due to destroyFailed state (cluster)")
+				p.logger.Info("skipping expired cluster in destroyFailed state, it needs manual removal",
+					zap.String("cluster-id", cluster.Meta.ID.String()),
+					zap.String("project-id", cluster.ProjectID))
 				continue
 			}
 			if cluster.Columnar != nil && cluster.Columnar.CurrentState == capellav4.StateDestroyFailed {
-				p.logger.Warn("skipping due to destroyFailed state (columnar)")
+				p.logger.Info("skipping expired columnar in destroyFailed state, it needs manual removal",
+					zap.String("cluster-id", cluster.Meta.ID.String()),
+					zap.String("project-id", cluster.ProjectID))
 				continue
 			}
+
+			p.logger.Info("removing cluster",
+				zap.String("cluster-id", cluster.Meta.ID.String()))
 
 			err := p.removeCluster(ctx, cluster)
 			if err != nil {

--- a/deployment/deployer.go
+++ b/deployment/deployer.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/couchbaselabs/cbdinocluster/clusterdef"
@@ -112,8 +113,27 @@ const (
 	DeltaRecovery RecoveryType = "delta"
 )
 
+// FilterClustersByPrefix keeps the clusters whose ID starts with idPrefix. An empty prefix keeps all.
+func FilterClustersByPrefix(clusters []ClusterInfo, idPrefix string) []ClusterInfo {
+	if idPrefix == "" {
+		return clusters
+	}
+
+	var out []ClusterInfo
+	for _, cluster := range clusters {
+		if strings.HasPrefix(cluster.GetID(), idPrefix) {
+			out = append(out, cluster)
+		}
+	}
+
+	return out
+}
+
 type Deployer interface {
 	ListClusters(ctx context.Context) ([]ClusterInfo, error)
+	// FindClusters returns the clusters whose ID starts with idPrefix, without
+	// listing everything the deployer owns where it can avoid it.
+	FindClusters(ctx context.Context, idPrefix string) ([]ClusterInfo, error)
 	NewCluster(ctx context.Context, def *clusterdef.Cluster) (ClusterInfo, error)
 	GetDefinition(ctx context.Context, clusterID string) (*clusterdef.Cluster, error)
 	UpdateClusterExpiry(ctx context.Context, clusterID string, newExpiryTime time.Time) error

--- a/deployment/dockerdeploy/deployer.go
+++ b/deployment/dockerdeploy/deployer.go
@@ -95,6 +95,15 @@ func (d *Deployer) ListClusters(ctx context.Context) ([]deployment.ClusterInfo, 
 	return out, nil
 }
 
+func (d *Deployer) FindClusters(ctx context.Context, idPrefix string) ([]deployment.ClusterInfo, error) {
+	clusters, err := d.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployment.FilterClustersByPrefix(clusters, idPrefix), nil
+}
+
 func (d *Deployer) NewCluster(ctx context.Context, def *clusterdef.Cluster) (deployment.ClusterInfo, error) {
 	clusterInfo, err := d.newCluster(ctx, def)
 	if err != nil {

--- a/deployment/localdeploy/deployer.go
+++ b/deployment/localdeploy/deployer.go
@@ -62,6 +62,15 @@ func (d *Deployer) ListClusters(ctx context.Context) ([]deployment.ClusterInfo, 
 	}, nil
 }
 
+func (d *Deployer) FindClusters(ctx context.Context, idPrefix string) ([]deployment.ClusterInfo, error) {
+	clusters, err := d.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployment.FilterClustersByPrefix(clusters, idPrefix), nil
+}
+
 func (d *Deployer) NewCluster(ctx context.Context, def *clusterdef.Cluster) (deployment.ClusterInfo, error) {
 	if len(def.NodeGroups) != 1 || def.NodeGroups[0].Count != 1 {
 		return nil, errors.New("local deployment only supports a single node")

--- a/utils/capellav4/analytics.go
+++ b/utils/capellav4/analytics.go
@@ -32,6 +32,8 @@ func (c *Client) ListAnalyticsClusters(ctx context.Context, orgID, projectID str
 	return listAll[*AnalyticsClusterInfo](ctx, c, path, nil)
 }
 
+// The response carries no project reference, so callers that need the project
+// must use ListAnalyticsClusters instead.
 func (c *Client) ListAllAnalyticsClusters(ctx context.Context, orgID string) ([]*AnalyticsClusterInfo, error) {
 	path := fmt.Sprintf("/v4/organizations/%s/analyticsClusters", orgID)
 	return listAll[*AnalyticsClusterInfo](ctx, c, path, nil)

--- a/utils/capellav4/client.go
+++ b/utils/capellav4/client.go
@@ -101,10 +101,10 @@ func isRetryable(err error) bool {
 		return true
 	}
 
+	// A rate limited request is not retried, so a busy window fails fast
+	// instead of stalling a run.
 	switch {
 	case apiErr.HttpStatusCode == http.StatusRequestTimeout:
-		return true
-	case apiErr.HttpStatusCode == http.StatusTooManyRequests:
 		return true
 	case apiErr.HttpStatusCode >= 500:
 		return true

--- a/utils/capellav4/client_test.go
+++ b/utils/capellav4/client_test.go
@@ -174,17 +174,39 @@ func TestReadDoesNotRetryClientError(t *testing.T) {
 	assert.Equal(t, int32(1), requests.Load())
 }
 
-func TestWriteIsNeverRetried(t *testing.T) {
+func TestReadDoesNotRetryRateLimit(t *testing.T) {
+	// The key pool is the rate limit strategy, so a 429 fails fast.
 	var requests atomic.Int32
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
-		w.WriteHeader(http.StatusServiceUnavailable)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
 	}))
 
-	_, err := client.CreateProject(context.Background(), "org", &CreateProjectRequest{Name: "n"})
+	_, err := client.GetCluster(context.Background(), "org", "proj", "clus")
 	require.Error(t, err)
 
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusTooManyRequests, apiErr.HttpStatusCode)
 	assert.Equal(t, int32(1), requests.Load())
+}
+
+func TestWriteIsNeverRetried(t *testing.T) {
+	for _, status := range []int{http.StatusServiceUnavailable, http.StatusTooManyRequests, http.StatusRequestTimeout} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			var requests atomic.Int32
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(status)
+			}))
+
+			_, err := client.CreateProject(context.Background(), "org", &CreateProjectRequest{Name: "n"})
+			require.Error(t, err)
+
+			assert.Equal(t, int32(1), requests.Load())
+		})
+	}
 }
 
 func TestCreateClusterOmitsUnsetServerVersionAndCidr(t *testing.T) {


### PR DESCRIPTION
## Motivation

Capella v4 has no organization wide cluster list, so cbdinocluster walked every project it owns to find one cluster. `ps <id>` ignored its argument and did that walk, which put a single waiting test over budget on its own.

## Changes

- A single cluster lookup now costs 3 calls instead of `1 + 2 * projects`, and a full listing inspects projects concurrently.
- `ps` and `list` now take a cluster id prefix. Bare `ps` is unchanged.
- `allocate` now builds its result from what it already knows, instead of reading the cluster back.
- The client now honours `Retry-After`, and falls back to backoff for everything else.
- Rate limit retries are capped at 3 so a request stalls a run for at most 3 minutes.
- Writes now retry on a rate limit only, where the request never reached the server.
- `cleanup` now leaves unexpired empty projects alone, since an allocate creates the project first.
- `cleanup` now reports a `destroyFailed` cluster as a skip, and fails on an unknown deployer name instead of reporting success.
- `ps` and `list` now report the purpose and the Capella project and cluster ids.