### PR TITLE
SDKQE-3993: Add Capella v4 API Key Pool 

### DIFF
--- a/cbdcconfig/config.go
+++ b/cbdcconfig/config.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const Version = 7
+const Version = 8
 
 type StringBool string
 
@@ -105,12 +105,28 @@ type Config_Azure struct {
 	_DefaultRegion string `yaml:"default-region"`
 }
 
+type Config_CapellaApiKey struct {
+	Key    string `yaml:"key"`
+	Secret string `yaml:"secret"`
+
+	// Empty for a hand entered key. Set to the Capella key name for a key
+	// cbdinocluster created, which is what makes it safe to rotate or delete.
+	Name string `yaml:"name,omitempty"`
+}
+
 type Config_Capella struct {
 	Enabled StringBool `yaml:"enabled"`
 
-	V4Endpoint string `yaml:"v4-endpoint"`
-	ApiKey     string `yaml:"api-key"`
-	ApiSecret  string `yaml:"api-secret"`
+	V4Endpoint string                 `yaml:"v4-endpoint"`
+	ApiKeys    []Config_CapellaApiKey `yaml:"api-keys,omitempty"`
+
+	// Names the key pool this machine owns in Capella. It is part of every
+	// pool key name, so it decides which keys cbdinocluster may manage.
+	PoolKeyName string `yaml:"pool-key-name,omitempty"`
+
+	// Superseded by ApiKeys. Upgrade folds these in and clears them.
+	ApiKey    string `yaml:"api-key,omitempty"`
+	ApiSecret string `yaml:"api-secret,omitempty"`
 
 	// The internal v2 API is only needed where v4 has no equivalent.
 	// Authentication invalidates any other active session for the same user.
@@ -214,6 +230,18 @@ func Upgrade(config *Config) *Config {
 	if config.Version < 7 {
 		config.Capella.V4Endpoint = DEFAULT_CAPELLA_V4_ENDPOINT
 		config.Version = 7
+	}
+
+	if config.Version < 8 {
+		if config.Capella.ApiSecret != "" {
+			config.Capella.ApiKeys = append(config.Capella.ApiKeys, Config_CapellaApiKey{
+				Key:    config.Capella.ApiKey,
+				Secret: config.Capella.ApiSecret,
+			})
+		}
+		config.Capella.ApiKey = ""
+		config.Capella.ApiSecret = ""
+		config.Version = 8
 	}
 
 	return config

--- a/cbdcconfig/config_test.go
+++ b/cbdcconfig/config_test.go
@@ -115,3 +115,41 @@ func TestSaveFailsWhenConfigDirCannotBeCreated(t *testing.T) {
 	require.Error(t, err)
 	require.NoFileExists(t, overridePath)
 }
+
+// TestUpgradeFoldsLegacyCapellaKey proves the version 8 migration moves the
+// single api-key/api-secret pair into the key list and clears the old fields,
+// so the next Save drops them from the file.
+func TestUpgradeFoldsLegacyCapellaKey(t *testing.T) {
+	ctx := context.Background()
+	setHomeDir(t, t.TempDir())
+	t.Setenv(cbdcconfig.EnvConfigPath, "")
+
+	configPath := filepath.Join(t.TempDir(), "legacy.yaml")
+	cbdcconfig.SetConfigPathOverride(configPath)
+	t.Cleanup(func() { cbdcconfig.SetConfigPathOverride("") })
+
+	require.NoError(t, os.WriteFile(configPath, []byte(
+		"version: 7\ncapella:\n  api-key: legacy-key\n  api-secret: legacy-secret\n"), 0600))
+
+	loaded, err := cbdcconfig.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, cbdcconfig.Version, loaded.Version)
+	require.Equal(t, []cbdcconfig.Config_CapellaApiKey{{
+		Key:    "legacy-key",
+		Secret: "legacy-secret",
+	}}, loaded.Capella.ApiKeys)
+	require.Empty(t, loaded.Capella.ApiKey)
+	require.Empty(t, loaded.Capella.ApiSecret)
+
+	saved, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(saved), "api-key:")
+	require.NotContains(t, string(saved), "api-secret:")
+	require.Contains(t, string(saved), "api-keys:")
+}
+
+func TestUpgradeWithoutLegacyCapellaKey(t *testing.T) {
+	cfg := cbdcconfig.Upgrade(&cbdcconfig.Config{Version: 7})
+	require.Equal(t, cbdcconfig.Version, cfg.Version)
+	require.Empty(t, cfg.Capella.ApiKeys)
+}

--- a/cmd/capellakeypool.go
+++ b/cmd/capellakeypool.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -17,6 +18,17 @@ const (
 	capellaPoolKeyUidLen      = 8
 	capellaPoolKeyUidAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 )
+
+const (
+	capellaPoolKeyMaxWaits  = 3
+	capellaPoolKeyMinWait   = 1 * time.Second
+	capellaPoolKeyMaxWait   = 60 * time.Second
+	capellaPoolKeyBlindWait = 60 * time.Second
+)
+
+// capellaPoolKeySleep is a variable so a test can record the waits instead of
+// spending them.
+var capellaPoolKeySleep = time.Sleep
 
 // capellaPoolKeyPrefix names the keys of one machine's pool. cbdinocluster only
 // ever creates, rotates or deletes a Capella API key whose name starts with it.
@@ -61,6 +73,38 @@ func capellaPoolKeyDescription(poolName string) string {
 	hostname, _ := os.Hostname()
 	return fmt.Sprintf("Created by cbdinocluster for %s on %s, %s.",
 		poolName, hostname, time.Now().Format("2006-01-02"))
+}
+
+// createCapellaPoolKey creates one pool key, and it is the only pool call that
+// waits out a rate limit. Every other call fails as soon as the whole key ring
+// is limited, but a pool that cannot grow leaves the machine short of keys for
+// the rest of the run.
+func createCapellaPoolKey(
+	ctx context.Context,
+	client *capellav4.Client,
+	orgID string,
+	req *capellav4.CreateApiKeyRequest,
+	sleep func(time.Duration),
+) (*capellav4.CreateApiKeyResponse, error) {
+	for waits := 0; ; waits++ {
+		createResp, err := client.CreateApiKey(ctx, orgID, req)
+		if err == nil || !capellav4.IsRateLimit(err) {
+			return createResp, err
+		}
+		if waits >= capellaPoolKeyMaxWaits {
+			return nil, err
+		}
+
+		sleep(capellaPoolKeyWait(err))
+	}
+}
+
+func capellaPoolKeyWait(err error) time.Duration {
+	wait := capellaPoolKeyBlindWait
+	if secs, ok := capellav4.RetryAfterSeconds(err); ok {
+		wait = time.Duration(secs) * time.Second
+	}
+	return min(max(wait, capellaPoolKeyMinWait), capellaPoolKeyMaxWait)
 }
 
 type capellaPoolPartition struct {
@@ -253,9 +297,11 @@ func capellaV4EndpointFor(config *cbdcconfig.Config) string {
 	return endpoint
 }
 
-// newCapellaPoolClient builds a client that uses the primary key alone. Key
-// management must not run over the round robin pool, a rotation there could
-// invalidate a secret another request is using at that moment.
+// newCapellaPoolClient builds a client that starts with the primary key alone.
+// The caller grows the ring with the pool secrets it has verified, so key
+// management shares the whole rate budget. A key's secret must leave the ring
+// before that key is rotated or deleted, a stale secret in the ring would fail
+// every call that draws it.
 func newCapellaPoolClient(config *cbdcconfig.Config, logger *zap.Logger) (*capellav4.Client, error) {
 	if !config.Capella.Enabled.Value() {
 		return nil, errors.New("capella is disabled, run `cbdinocluster init` to enable it")

--- a/cmd/capellakeypool.go
+++ b/cmd/capellakeypool.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/couchbaselabs/cbdinocluster/utils/capellav4"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	capellaPoolKeyUidLen      = 8
+	capellaPoolKeyUidAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+// capellaPoolKeyPrefix names the keys of one machine's pool. cbdinocluster only
+// ever creates, rotates or deletes a Capella API key whose name starts with it.
+func capellaPoolKeyPrefix(poolName string) string {
+	return fmt.Sprintf("cbdino_pool_%s_", poolName)
+}
+
+func newCapellaPoolKeyName(poolName string) (string, error) {
+	uid, err := newCapellaPoolKeyUid()
+	if err != nil {
+		return "", err
+	}
+	return capellaPoolKeyPrefix(poolName) + uid, nil
+}
+
+func newCapellaPoolKeyUid() (string, error) {
+	// 36 * 7, so a modulo cannot favour the first letters of the alphabet.
+	const maxUnbiased = byte(252)
+
+	uid := make([]byte, 0, capellaPoolKeyUidLen)
+	buf := make([]byte, capellaPoolKeyUidLen)
+	for len(uid) < capellaPoolKeyUidLen {
+		if _, err := rand.Read(buf); err != nil {
+			return "", errors.Wrap(err, "failed to read random bytes")
+		}
+
+		for _, b := range buf {
+			if b >= maxUnbiased {
+				continue
+			}
+			uid = append(uid, capellaPoolKeyUidAlphabet[int(b)%len(capellaPoolKeyUidAlphabet)])
+			if len(uid) == capellaPoolKeyUidLen {
+				break
+			}
+		}
+	}
+
+	return string(uid), nil
+}
+
+func capellaPoolKeyDescription(poolName string) string {
+	hostname, _ := os.Hostname()
+	return fmt.Sprintf("Created by cbdinocluster for %s on %s, %s.",
+		poolName, hostname, time.Now().Format("2006-01-02"))
+}
+
+type capellaPoolPartition struct {
+	// Saved keys Capella still lists.
+	Matched []cbdcconfig.Config_CapellaApiKey
+	// Saved keys Capella no longer lists, so their secret is worthless.
+	Missing []cbdcconfig.Config_CapellaApiKey
+	// Pool keys Capella lists that this machine holds no secret for. The v4
+	// API never gives a secret back, so only a rotation recovers them.
+	Orphans []*capellav4.ApiKeyInfo
+}
+
+// partitionCapellaPoolKeys compares the saved pool keys against the pool keys
+// Capella reports. The primary key is left out of every group, it is the key
+// that manages the pool and must never be rotated or deleted.
+func partitionCapellaPoolKeys(
+	prefix, primaryKeyID string,
+	configKeys []cbdcconfig.Config_CapellaApiKey,
+	remoteKeys []*capellav4.ApiKeyInfo,
+) capellaPoolPartition {
+	remoteByID := make(map[string]*capellav4.ApiKeyInfo, len(remoteKeys))
+	for _, remoteKey := range remoteKeys {
+		if !strings.HasPrefix(remoteKey.Name, prefix) {
+			continue
+		}
+		remoteByID[remoteKey.ID] = remoteKey
+	}
+
+	var out capellaPoolPartition
+	configIDs := make(map[string]bool, len(configKeys))
+	for _, configKey := range configKeys {
+		if configKey.Key != "" {
+			configIDs[configKey.Key] = true
+		}
+		if configKey.Key == primaryKeyID || !strings.HasPrefix(configKey.Name, prefix) {
+			continue
+		}
+
+		if remoteByID[configKey.Key] != nil {
+			out.Matched = append(out.Matched, configKey)
+		} else {
+			out.Missing = append(out.Missing, configKey)
+		}
+	}
+
+	for _, remoteKey := range remoteKeys {
+		if !strings.HasPrefix(remoteKey.Name, prefix) {
+			continue
+		}
+		if remoteKey.ID == primaryKeyID || configIDs[remoteKey.ID] {
+			continue
+		}
+		out.Orphans = append(out.Orphans, remoteKey)
+	}
+
+	return out
+}
+
+func countCapellaPoolKeys(
+	prefix, primaryKeyID string,
+	configKeys []cbdcconfig.Config_CapellaApiKey,
+) int {
+	count := 0
+	for _, configKey := range configKeys {
+		if configKey.Key == primaryKeyID || !strings.HasPrefix(configKey.Name, prefix) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// selectCapellaPoolConfigKeys picks the saved keys to act on. Without ids it
+// takes the whole pool, otherwise only the ids given, and it refuses an id that
+// is not a pool key this machine holds.
+func selectCapellaPoolConfigKeys(
+	prefix, primaryKeyID string,
+	configKeys []cbdcconfig.Config_CapellaApiKey,
+	keyIDs []string,
+) ([]cbdcconfig.Config_CapellaApiKey, error) {
+	poolKeys := make(map[string]cbdcconfig.Config_CapellaApiKey, len(configKeys))
+	var allKeys []cbdcconfig.Config_CapellaApiKey
+	for _, configKey := range configKeys {
+		if configKey.Key == primaryKeyID || !strings.HasPrefix(configKey.Name, prefix) {
+			continue
+		}
+		poolKeys[configKey.Key] = configKey
+		allKeys = append(allKeys, configKey)
+	}
+
+	if len(keyIDs) == 0 {
+		return allKeys, nil
+	}
+
+	var selected []cbdcconfig.Config_CapellaApiKey
+	for _, keyID := range keyIDs {
+		poolKey, ok := poolKeys[keyID]
+		if !ok {
+			return nil, errors.Errorf("%s is not a saved %s pool key", keyID, prefix)
+		}
+		selected = append(selected, poolKey)
+	}
+
+	return selected, nil
+}
+
+// selectCapellaPoolRemoteKeys picks the keys to act on from what Capella
+// reports, with the same rules as selectCapellaPoolConfigKeys.
+func selectCapellaPoolRemoteKeys(
+	prefix, primaryKeyID string,
+	remoteKeys []*capellav4.ApiKeyInfo,
+	keyIDs []string,
+) ([]*capellav4.ApiKeyInfo, error) {
+	poolKeys := make(map[string]*capellav4.ApiKeyInfo, len(remoteKeys))
+	var allKeys []*capellav4.ApiKeyInfo
+	for _, remoteKey := range remoteKeys {
+		if remoteKey.ID == primaryKeyID || !strings.HasPrefix(remoteKey.Name, prefix) {
+			continue
+		}
+		poolKeys[remoteKey.ID] = remoteKey
+		allKeys = append(allKeys, remoteKey)
+	}
+
+	if len(keyIDs) == 0 {
+		return allKeys, nil
+	}
+
+	var selected []*capellav4.ApiKeyInfo
+	for _, keyID := range keyIDs {
+		poolKey, ok := poolKeys[keyID]
+		if !ok {
+			return nil, errors.Errorf("%s is not a %s pool key in capella", keyID, prefix)
+		}
+		selected = append(selected, poolKey)
+	}
+
+	return selected, nil
+}
+
+// checkCapellaPoolKeyTarget guards every rotate and delete. A key cbdinocluster
+// did not create can belong to anyone in the organization, and the primary key
+// is the one that manages the pool.
+func checkCapellaPoolKeyTarget(prefix, primaryKeyID, keyID, keyName string) error {
+	if keyID == "" {
+		return errors.New("refusing to touch a capella api key with no id")
+	}
+	if keyID == primaryKeyID {
+		return errors.Errorf("refusing to touch the primary capella api key %s", keyID)
+	}
+	if !strings.HasPrefix(keyName, prefix) {
+		return errors.Errorf("refusing to touch the capella api key %s, "+
+			"its name is not part of the %s pool", keyID, prefix)
+	}
+	return nil
+}
+
+// capellaRequestSecrets picks the secrets the round robin client rotates over.
+// Pool keys with a secret carry all the request traffic, which keeps the
+// primary key's own rate budget free for pool management and for other tools
+// that share it. Without a usable pool key the primary serves alone.
+func capellaRequestSecrets(apiKeys []cbdcconfig.Config_CapellaApiKey) []string {
+	if len(apiKeys) == 0 {
+		return nil
+	}
+
+	var poolSecrets []string
+	for _, apiKey := range apiKeys[1:] {
+		if apiKey.Secret != "" {
+			poolSecrets = append(poolSecrets, apiKey.Secret)
+		}
+	}
+	if len(poolSecrets) > 0 {
+		return poolSecrets
+	}
+
+	if apiKeys[0].Secret == "" {
+		return nil
+	}
+	return []string{apiKeys[0].Secret}
+}
+
+func capellaV4EndpointFor(config *cbdcconfig.Config) string {
+	endpoint := config.Capella.V4Endpoint
+	if endpoint == "" {
+		endpoint = os.Getenv("CAPELLA_V4_ENDPOINT")
+	}
+	if endpoint == "" {
+		endpoint = cbdcconfig.DEFAULT_CAPELLA_V4_ENDPOINT
+	}
+	return endpoint
+}
+
+// newCapellaPoolClient builds a client that uses the primary key alone. Key
+// management must not run over the round robin pool, a rotation there could
+// invalidate a secret another request is using at that moment.
+func newCapellaPoolClient(config *cbdcconfig.Config, logger *zap.Logger) (*capellav4.Client, error) {
+	if !config.Capella.Enabled.Value() {
+		return nil, errors.New("capella is disabled, run `cbdinocluster init` to enable it")
+	}
+	if len(config.Capella.ApiKeys) == 0 || config.Capella.ApiKeys[0].Secret == "" {
+		return nil, errors.New("no primary capella api key is configured, run `cbdinocluster init`")
+	}
+
+	client, err := capellav4.NewClient(&capellav4.ClientOptions{
+		Logger:     logger,
+		Endpoint:   capellaV4EndpointFor(config),
+		SecretKeys: []string{config.Capella.ApiKeys[0].Secret},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create capella v4 client")
+	}
+
+	return client, nil
+}
+
+type capellaPoolSession struct {
+	Client       *capellav4.Client
+	OrgID        string
+	Prefix       string
+	PrimaryKeyID string
+	PoolName     string
+}
+
+func newCapellaPoolSession(config *cbdcconfig.Config, logger *zap.Logger) (*capellaPoolSession, error) {
+	client, err := newCapellaPoolClient(config, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	poolName := config.Capella.PoolKeyName
+	if poolName == "" {
+		return nil, errors.New("no capella api key pool is configured, " +
+			"run `cbdinocluster init` and give the pool a name")
+	}
+	if config.Capella.OrganizationID == "" {
+		return nil, errors.New("no capella organization id is configured, run `cbdinocluster init`")
+	}
+
+	return &capellaPoolSession{
+		Client:       client,
+		OrgID:        config.Capella.OrganizationID,
+		Prefix:       capellaPoolKeyPrefix(poolName),
+		PrimaryKeyID: config.Capella.ApiKeys[0].Key,
+		PoolName:     poolName,
+	}, nil
+}

--- a/cmd/capellakeypool_test.go
+++ b/cmd/capellakeypool_test.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/couchbaselabs/cbdinocluster/utils/capellav4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapellaPoolKeyPrefix(t *testing.T) {
+	assert.Equal(t, "cbdino_pool_emilienbev_", capellaPoolKeyPrefix("emilienbev"))
+}
+
+// A duplicate name is rejected by Capella, so the uid must be unique and it
+// must stay inside the alphabet the key name allows.
+func TestNewCapellaPoolKeyName(t *testing.T) {
+	const draws = 5000
+
+	prefix := capellaPoolKeyPrefix("test")
+	seen := make(map[string]bool, draws)
+
+	for i := 0; i < draws; i++ {
+		name, err := newCapellaPoolKeyName("test")
+		require.NoError(t, err)
+
+		require.True(t, strings.HasPrefix(name, prefix), "name %s has no pool prefix", name)
+
+		uid := strings.TrimPrefix(name, prefix)
+		require.Len(t, uid, capellaPoolKeyUidLen)
+		for _, char := range uid {
+			require.True(t, strings.ContainsRune(capellaPoolKeyUidAlphabet, char),
+				"uid %s uses the unexpected character %q", uid, char)
+		}
+
+		require.False(t, seen[uid], "uid %s was drawn twice", uid)
+		seen[uid] = true
+	}
+}
+
+func TestPartitionCapellaPoolKeys(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+	const primaryKeyID = "primary"
+
+	configKeys := []cbdcconfig.Config_CapellaApiKey{
+		{Key: primaryKeyID, Secret: "primary-secret"},
+		{Key: "hand-entered", Secret: "hand-secret"},
+		{Key: "pool-kept", Secret: "kept-secret", Name: prefix + "aaaaaaaa"},
+		{Key: "pool-gone", Secret: "gone-secret", Name: prefix + "bbbbbbbb"},
+		{Key: "other-pool", Secret: "other-secret", Name: "cbdino_pool_other_cccccccc"},
+	}
+	remoteKeys := []*capellav4.ApiKeyInfo{
+		{ID: primaryKeyID, Name: "hand made primary"},
+		{ID: "pool-kept", Name: prefix + "aaaaaaaa"},
+		{ID: "pool-orphan", Name: prefix + "dddddddd"},
+		{ID: "someone-else", Name: "someone else's key"},
+		{ID: "other-pool-remote", Name: "cbdino_pool_other_eeeeeeee"},
+	}
+
+	parts := partitionCapellaPoolKeys(prefix, primaryKeyID, configKeys, remoteKeys)
+
+	require.Len(t, parts.Matched, 1)
+	assert.Equal(t, "pool-kept", parts.Matched[0].Key)
+
+	require.Len(t, parts.Missing, 1)
+	assert.Equal(t, "pool-gone", parts.Missing[0].Key)
+
+	require.Len(t, parts.Orphans, 1)
+	assert.Equal(t, "pool-orphan", parts.Orphans[0].ID)
+}
+
+// The primary key manages the pool, so it must stay out of every group even
+// when its name happens to match the pool prefix.
+func TestPartitionCapellaPoolKeysSkipsThePrimaryKey(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+	const primaryKeyID = "primary"
+
+	configKeys := []cbdcconfig.Config_CapellaApiKey{
+		{Key: primaryKeyID, Secret: "primary-secret", Name: prefix + "aaaaaaaa"},
+	}
+	remoteKeys := []*capellav4.ApiKeyInfo{
+		{ID: primaryKeyID, Name: prefix + "aaaaaaaa"},
+	}
+
+	parts := partitionCapellaPoolKeys(prefix, primaryKeyID, configKeys, remoteKeys)
+
+	assert.Empty(t, parts.Matched)
+	assert.Empty(t, parts.Missing)
+	assert.Empty(t, parts.Orphans)
+}
+
+func TestCountCapellaPoolKeys(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+
+	configKeys := []cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-one", Secret: "one", Name: prefix + "aaaaaaaa"},
+		{Key: "pool-two", Secret: "two", Name: prefix + "bbbbbbbb"},
+		{Key: "other-pool", Secret: "three", Name: "cbdino_pool_other_cccccccc"},
+	}
+
+	assert.Equal(t, 2, countCapellaPoolKeys(prefix, "primary", configKeys))
+}
+
+func TestCheckCapellaPoolKeyTarget(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+
+	require.NoError(t, checkCapellaPoolKeyTarget(prefix, "primary", "pool-one", prefix+"aaaaaaaa"))
+
+	require.Error(t, checkCapellaPoolKeyTarget(prefix, "primary", "", prefix+"aaaaaaaa"))
+	require.Error(t, checkCapellaPoolKeyTarget(prefix, "primary", "primary", prefix+"aaaaaaaa"))
+	require.Error(t, checkCapellaPoolKeyTarget(prefix, "primary", "pool-one", "someone else's key"))
+	require.Error(t, checkCapellaPoolKeyTarget(prefix, "primary", "pool-one", "cbdino_pool_other_aaaaaaaa"))
+}
+
+func TestSelectCapellaPoolConfigKeys(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+
+	configKeys := []cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "hand-entered", Secret: "hand-secret"},
+		{Key: "pool-one", Secret: "one", Name: prefix + "aaaaaaaa"},
+		{Key: "pool-two", Secret: "two", Name: prefix + "bbbbbbbb"},
+	}
+
+	all, err := selectCapellaPoolConfigKeys(prefix, "primary", configKeys, nil)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	assert.Equal(t, "pool-one", all[0].Key)
+	assert.Equal(t, "pool-two", all[1].Key)
+
+	some, err := selectCapellaPoolConfigKeys(prefix, "primary", configKeys, []string{"pool-two"})
+	require.NoError(t, err)
+	require.Len(t, some, 1)
+	assert.Equal(t, "pool-two", some[0].Key)
+
+	_, err = selectCapellaPoolConfigKeys(prefix, "primary", configKeys, []string{"primary"})
+	require.Error(t, err)
+
+	_, err = selectCapellaPoolConfigKeys(prefix, "primary", configKeys, []string{"hand-entered"})
+	require.Error(t, err)
+
+	_, err = selectCapellaPoolConfigKeys(prefix, "primary", configKeys, []string{"unknown"})
+	require.Error(t, err)
+}
+
+func TestSelectCapellaPoolRemoteKeys(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+
+	remoteKeys := []*capellav4.ApiKeyInfo{
+		{ID: "primary", Name: "hand made primary"},
+		{ID: "pool-one", Name: prefix + "aaaaaaaa"},
+		{ID: "someone-else", Name: "someone else's key"},
+	}
+
+	all, err := selectCapellaPoolRemoteKeys(prefix, "primary", remoteKeys, nil)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, "pool-one", all[0].ID)
+
+	_, err = selectCapellaPoolRemoteKeys(prefix, "primary", remoteKeys, []string{"someone-else"})
+	require.Error(t, err)
+
+	_, err = selectCapellaPoolRemoteKeys(prefix, "primary", remoteKeys, []string{"primary"})
+	require.Error(t, err)
+}
+
+// The primary key stays out of the request rotation as soon as one pool key
+// holds a secret, and serves alone otherwise.
+func TestCapellaRequestSecrets(t *testing.T) {
+	const prefix = "cbdino_pool_test_"
+
+	primary := cbdcconfig.Config_CapellaApiKey{Key: "primary", Secret: "primary-secret"}
+	poolOne := cbdcconfig.Config_CapellaApiKey{Key: "pool-one", Secret: "one", Name: prefix + "aaaaaaaa"}
+	poolTwo := cbdcconfig.Config_CapellaApiKey{Key: "pool-two", Secret: "two", Name: prefix + "bbbbbbbb"}
+	poolNoSecret := cbdcconfig.Config_CapellaApiKey{Key: "pool-bare", Name: prefix + "cccccccc"}
+
+	assert.Nil(t, capellaRequestSecrets(nil))
+	assert.Nil(t, capellaRequestSecrets([]cbdcconfig.Config_CapellaApiKey{{Key: "primary"}}))
+
+	assert.Equal(t, []string{"primary-secret"},
+		capellaRequestSecrets([]cbdcconfig.Config_CapellaApiKey{primary}))
+	assert.Equal(t, []string{"primary-secret"},
+		capellaRequestSecrets([]cbdcconfig.Config_CapellaApiKey{primary, poolNoSecret}))
+
+	assert.Equal(t, []string{"one", "two"},
+		capellaRequestSecrets([]cbdcconfig.Config_CapellaApiKey{primary, poolOne, poolTwo}))
+}
+
+func TestNewCapellaPoolSessionRequiresConfiguration(t *testing.T) {
+	enabled := cbdcconfig.StringBool("true")
+
+	_, err := newCapellaPoolSession(&cbdcconfig.Config{}, nil)
+	require.Error(t, err)
+
+	_, err = newCapellaPoolSession(&cbdcconfig.Config{
+		Capella: cbdcconfig.Config_Capella{Enabled: enabled},
+	}, nil)
+	require.Error(t, err)
+
+	_, err = newCapellaPoolSession(&cbdcconfig.Config{
+		Capella: cbdcconfig.Config_Capella{
+			Enabled:        enabled,
+			ApiKeys:        []cbdcconfig.Config_CapellaApiKey{{Key: "primary", Secret: "secret"}},
+			OrganizationID: "org",
+		},
+	}, nil)
+	require.Error(t, err, "a session must not start without a pool name")
+
+	session, err := newCapellaPoolSession(&cbdcconfig.Config{
+		Capella: cbdcconfig.Config_Capella{
+			Enabled:        enabled,
+			ApiKeys:        []cbdcconfig.Config_CapellaApiKey{{Key: "primary", Secret: "secret"}},
+			OrganizationID: "org",
+			PoolKeyName:    "test",
+			V4Endpoint:     "http://127.0.0.1:1",
+		},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cbdino_pool_test_", session.Prefix)
+	assert.Equal(t, "primary", session.PrimaryKeyID)
+	assert.Equal(t, "org", session.OrgID)
+}

--- a/cmd/cloud-apikeys-list.go
+++ b/cmd/cloud-apikeys-list.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var cloudApiKeysListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "Lists the Capella API keys of the pool",
+	Args:    cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+		config := helper.GetConfig(ctx)
+
+		session, err := newCapellaPoolSession(config, helper.GetInternalLogger())
+		if err != nil {
+			logger.Fatal("cannot access the capella api key pool", zap.Error(err))
+		}
+
+		remoteKeys, err := session.Client.ListApiKeys(ctx, session.OrgID)
+		if err != nil {
+			logger.Fatal("failed to list the capella api keys", zap.Error(err))
+		}
+
+		heldSecrets := make(map[string]bool, len(config.Capella.ApiKeys))
+		for _, savedKey := range config.Capella.ApiKeys {
+			if savedKey.Key != "" && savedKey.Secret != "" {
+				heldSecrets[savedKey.Key] = true
+			}
+		}
+
+		fmt.Printf("API Keys (pool: %s):\n", session.PoolName)
+		for _, remoteKey := range remoteKeys {
+			isPrimary := remoteKey.ID == session.PrimaryKeyID
+			if !isPrimary && !strings.HasPrefix(remoteKey.Name, session.Prefix) {
+				continue
+			}
+
+			marker := ""
+			if isPrimary {
+				marker = " [primary]"
+			}
+
+			fmt.Printf("  %s (%s) [HasSecret: %t]%s\n",
+				remoteKey.ID, remoteKey.Name, heldSecrets[remoteKey.ID], marker)
+		}
+	},
+}
+
+func init() {
+	cloudApiKeysCmd.AddCommand(cloudApiKeysListCmd)
+}

--- a/cmd/cloud-apikeys-remove.go
+++ b/cmd/cloud-apikeys-remove.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var cloudApiKeysRemoveCmd = &cobra.Command{
+	Use:     "remove [key-id ...]",
+	Aliases: []string{"delete"},
+	Short:   "Removes the pool Capella API keys from Capella",
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+		config := helper.GetConfig(ctx)
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		session, err := newCapellaPoolSession(config, helper.GetInternalLogger())
+		if err != nil {
+			logger.Fatal("cannot access the capella api key pool", zap.Error(err))
+		}
+
+		remoteKeys, err := session.Client.ListApiKeys(ctx, session.OrgID)
+		if err != nil {
+			logger.Fatal("failed to list the capella api keys", zap.Error(err))
+		}
+
+		targetKeys, err := selectCapellaPoolRemoteKeys(session.Prefix, session.PrimaryKeyID,
+			remoteKeys, args)
+		if err != nil {
+			logger.Fatal("failed to select the capella api keys to remove", zap.Error(err))
+		}
+		if len(targetKeys) == 0 {
+			fmt.Printf("There are no pool Capella API keys to remove.\n")
+			return
+		}
+
+		failed := false
+		removedKeys := make(map[string]bool, len(targetKeys))
+		for _, targetKey := range targetKeys {
+			err := checkCapellaPoolKeyTarget(session.Prefix, session.PrimaryKeyID,
+				targetKey.ID, targetKey.Name)
+			if err != nil {
+				logger.Fatal("refused to remove a capella api key", zap.Error(err))
+			}
+
+			if dryRun {
+				fmt.Printf("Would remove the Capella API key %s (%s).\n",
+					targetKey.ID, targetKey.Name)
+				continue
+			}
+
+			err = session.Client.DeleteApiKey(ctx, session.OrgID, targetKey.ID)
+			if err != nil {
+				failed = true
+				logger.Error("failed to remove a capella api key",
+					zap.String("keyId", targetKey.ID), zap.Error(err))
+				continue
+			}
+
+			removedKeys[targetKey.ID] = true
+			fmt.Printf("Removed the Capella API key %s (%s).\n", targetKey.ID, targetKey.Name)
+		}
+
+		if len(removedKeys) > 0 {
+			keptKeys := make([]cbdcconfig.Config_CapellaApiKey, 0, len(config.Capella.ApiKeys))
+			for _, savedKey := range config.Capella.ApiKeys {
+				if removedKeys[savedKey.Key] {
+					continue
+				}
+				keptKeys = append(keptKeys, savedKey)
+			}
+			config.Capella.ApiKeys = keptKeys
+
+			err := cbdcconfig.Save(ctx, config)
+			if err != nil {
+				logger.Fatal("failed to save the config", zap.Error(err))
+			}
+		}
+
+		if failed {
+			logger.Fatal("one or more capella api keys could not be removed")
+		}
+	},
+}
+
+func init() {
+	cloudApiKeysCmd.AddCommand(cloudApiKeysRemoveCmd)
+
+	cloudApiKeysRemoveCmd.Flags().Bool("dry-run", false,
+		"Disables the actual removal and simply does a dry-run.")
+}

--- a/cmd/cloud-apikeys-remove.go
+++ b/cmd/cloud-apikeys-remove.go
@@ -30,6 +30,19 @@ var cloudApiKeysRemoveCmd = &cobra.Command{
 			logger.Fatal("failed to list the capella api keys", zap.Error(err))
 		}
 
+		// Only a saved secret Capella still lists can serve a request, so the
+		// deletions spread over the pool instead of loading the primary key.
+		poolKeys := partitionCapellaPoolKeys(session.Prefix, session.PrimaryKeyID,
+			config.Capella.ApiKeys, remoteKeys)
+		for _, matchedKey := range poolKeys.Matched {
+			session.Client.AddSecretKey(matchedKey.Secret)
+		}
+
+		savedSecrets := make(map[string]string, len(config.Capella.ApiKeys))
+		for _, savedKey := range config.Capella.ApiKeys {
+			savedSecrets[savedKey.Key] = savedKey.Secret
+		}
+
 		targetKeys, err := selectCapellaPoolRemoteKeys(session.Prefix, session.PrimaryKeyID,
 			remoteKeys, args)
 		if err != nil {
@@ -54,6 +67,10 @@ var cloudApiKeysRemoveCmd = &cobra.Command{
 					targetKey.ID, targetKey.Name)
 				continue
 			}
+
+			// A deleted key cannot authorize anything, so its secret leaves the
+			// ring before the request that kills it.
+			session.Client.RemoveSecretKey(savedSecrets[targetKey.ID])
 
 			err = session.Client.DeleteApiKey(ctx, session.OrgID, targetKey.ID)
 			if err != nil {

--- a/cmd/cloud-apikeys-rotate.go
+++ b/cmd/cloud-apikeys-rotate.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var cloudApiKeysRotateCmd = &cobra.Command{
+	Use:   "rotate [key-id ...]",
+	Short: "Rotates the secrets of the pool Capella API keys",
+	Run: func(cmd *cobra.Command, args []string) {
+		helper := CmdHelper{}
+		logger := helper.GetLogger()
+		ctx := helper.GetContext()
+		config := helper.GetConfig(ctx)
+
+		session, err := newCapellaPoolSession(config, helper.GetInternalLogger())
+		if err != nil {
+			logger.Fatal("cannot access the capella api key pool", zap.Error(err))
+		}
+
+		targetKeys, err := selectCapellaPoolConfigKeys(session.Prefix, session.PrimaryKeyID,
+			config.Capella.ApiKeys, args)
+		if err != nil {
+			logger.Fatal("failed to select the capella api keys to rotate", zap.Error(err))
+		}
+		if len(targetKeys) == 0 {
+			fmt.Printf("There are no pool Capella API keys to rotate.\n")
+			return
+		}
+
+		failed := false
+		for _, targetKey := range targetKeys {
+			err := checkCapellaPoolKeyTarget(session.Prefix, session.PrimaryKeyID,
+				targetKey.Key, targetKey.Name)
+			if err != nil {
+				logger.Fatal("refused to rotate a capella api key", zap.Error(err))
+			}
+
+			rotateResp, err := session.Client.RotateApiKey(ctx, session.OrgID, targetKey.Key)
+			if err != nil {
+				failed = true
+				logger.Error("failed to rotate a capella api key",
+					zap.String("keyId", targetKey.Key), zap.Error(err))
+				continue
+			}
+
+			// The old secret stops working at once, so the new one is saved
+			// before the next key is rotated.
+			for i := range config.Capella.ApiKeys {
+				if config.Capella.ApiKeys[i].Key == targetKey.Key {
+					config.Capella.ApiKeys[i].Secret = rotateResp.Token
+				}
+			}
+
+			err = cbdcconfig.Save(ctx, config)
+			if err != nil {
+				logger.Fatal("failed to save the rotated capella api key secret",
+					zap.String("keyId", targetKey.Key), zap.Error(err))
+			}
+
+			fmt.Printf("Rotated the Capella API key %s (%s).\n", targetKey.Key, targetKey.Name)
+		}
+
+		if failed {
+			logger.Fatal("one or more capella api keys could not be rotated")
+		}
+	},
+}
+
+func init() {
+	cloudApiKeysCmd.AddCommand(cloudApiKeysRotateCmd)
+}

--- a/cmd/cloud-apikeys-rotate.go
+++ b/cmd/cloud-apikeys-rotate.go
@@ -22,6 +22,19 @@ var cloudApiKeysRotateCmd = &cobra.Command{
 			logger.Fatal("cannot access the capella api key pool", zap.Error(err))
 		}
 
+		remoteKeys, err := session.Client.ListApiKeys(ctx, session.OrgID)
+		if err != nil {
+			logger.Fatal("failed to list the capella api keys", zap.Error(err))
+		}
+
+		// Only a saved secret Capella still lists can serve a request, so the
+		// rotations spread over the pool instead of loading the primary key.
+		poolKeys := partitionCapellaPoolKeys(session.Prefix, session.PrimaryKeyID,
+			config.Capella.ApiKeys, remoteKeys)
+		for _, matchedKey := range poolKeys.Matched {
+			session.Client.AddSecretKey(matchedKey.Secret)
+		}
+
 		targetKeys, err := selectCapellaPoolConfigKeys(session.Prefix, session.PrimaryKeyID,
 			config.Capella.ApiKeys, args)
 		if err != nil {
@@ -40,6 +53,10 @@ var cloudApiKeysRotateCmd = &cobra.Command{
 				logger.Fatal("refused to rotate a capella api key", zap.Error(err))
 			}
 
+			// The rotation kills this secret, so it leaves the ring first. A
+			// failed rotation leaves it out too, its state is unknown.
+			session.Client.RemoveSecretKey(targetKey.Secret)
+
 			rotateResp, err := session.Client.RotateApiKey(ctx, session.OrgID, targetKey.Key)
 			if err != nil {
 				failed = true
@@ -47,6 +64,8 @@ var cloudApiKeysRotateCmd = &cobra.Command{
 					zap.String("keyId", targetKey.Key), zap.Error(err))
 				continue
 			}
+
+			session.Client.AddSecretKey(rotateResp.Token)
 
 			// The old secret stops working at once, so the new one is saved
 			// before the next key is rotated.

--- a/cmd/cloud-apikeys.go
+++ b/cmd/cloud-apikeys.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cloudApiKeysCmd = &cobra.Command{
+	Use:   "apikeys",
+	Short: "Manages the cbdinocluster created Capella API key pool",
+	Run:   nil,
+}
+
+func init() {
+	cloudCmd.AddCommand(cloudApiKeysCmd)
+}

--- a/cmd/cmdhelper.go
+++ b/cmd/cmdhelper.go
@@ -206,11 +206,15 @@ func (h *CmdHelper) getCloudDeployer(ctx context.Context) (*clouddeploy.Deployer
 	capellaInternalSupportToken := config.Capella.InternalSupportToken
 	uploadServerLogsHostName := config.Capella.UploadServerLogsHostName
 
-	capellaApiSecret := config.Capella.ApiSecret
-	if capellaApiSecret == "" {
-		capellaApiSecret = os.Getenv("CAPELLA_API_SECRET")
+	capellaApiKeys := appendApiKeys(nil, config.Capella.ApiKeys...)
+	if len(capellaApiKeys) == 0 {
+		capellaApiKeys = appendApiKeys(capellaApiKeys, cbdcconfig.Config_CapellaApiKey{
+			Secret: os.Getenv("CAPELLA_API_SECRET"),
+		})
 	}
-	if capellaApiSecret == "" {
+
+	capellaApiSecrets := capellaRequestSecrets(capellaApiKeys)
+	if len(capellaApiSecrets) == 0 {
 		return nil, errors.New("a capella api secret is required; run `cbdinocluster init` " +
 			"or set CAPELLA_API_SECRET")
 	}
@@ -224,9 +228,9 @@ func (h *CmdHelper) getCloudDeployer(ctx context.Context) (*clouddeploy.Deployer
 	}
 
 	v4Client, err := capellav4.NewClient(&capellav4.ClientOptions{
-		Logger:    logger,
-		Endpoint:  v4Endpoint,
-		SecretKey: capellaApiSecret,
+		Logger:     logger,
+		Endpoint:   v4Endpoint,
+		SecretKeys: capellaApiSecrets,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create capella v4 client")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2005,7 +2005,7 @@ func init() {
 	initCmd.Flags().String("capella-api-secret", "", "Capella organization API secret to use")
 	initCmd.Flags().Bool("capella-create-pool", false, "Create the Capella API keys the key pool is missing")
 	initCmd.Flags().String("capella-pool-name", "", "Name that identifies this machine's Capella API key pool")
-	initCmd.Flags().Int("capella-pool-size", 10, "Number of Capella API keys the key pool should hold")
+	initCmd.Flags().Int("capella-pool-size", 3, "Number of Capella API keys the key pool should hold")
 	initCmd.Flags().Float64("capella-pool-expiry", 0.5,
 		"Days until a created pool key expires, -1 means never")
 	initCmd.Flags().String("capella-endpoint", "", "Capella v2 endpoint to use")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1346,9 +1346,9 @@ var initCmd = &cobra.Command{
 					poolPrefix := capellaPoolKeyPrefix(poolName)
 					primaryKeyID := capellaApiKeys[0].Key
 
-					// Key management must not run over the round robin pool, a
-					// rotation there could invalidate a secret another request is
-					// using at that moment.
+					// The ring starts with the primary key alone and grows with
+					// every pool secret this section verifies. A key's secret
+					// leaves the ring before that key is rotated or deleted.
 					poolClient, err := capellav4.NewClient(&capellav4.ClientOptions{
 						Logger:     logger,
 						Endpoint:   capellaV4Endpoint,
@@ -1424,6 +1424,8 @@ var initCmd = &cobra.Command{
 										orphanKey.ID, err)
 									continue
 								}
+
+								poolClient.AddSecretKey(rotateResp.Token)
 
 								capellaApiKeys = append(capellaApiKeys,
 									cbdcconfig.Config_CapellaApiKey{
@@ -1529,18 +1531,20 @@ var initCmd = &cobra.Command{
 									break
 								}
 
-								createResp, err := poolClient.CreateApiKey(ctx, capellaOid,
+								createResp, err := createCapellaPoolKey(ctx, poolClient, capellaOid,
 									&capellav4.CreateApiKeyRequest{
 										Name:              keyName,
 										Description:       capellaPoolKeyDescription(poolName),
 										Expiry:            poolExpiry,
 										OrganizationRoles: []string{capellav4.OrganizationRoleOwner},
-									})
+									}, capellaPoolKeySleep)
 								if err != nil {
 									fmt.Printf("Failed to create a Capella API key:\n  %s\n", err)
 									createFailed = true
 									break
 								}
+
+								poolClient.AddSecretKey(createResp.Token)
 
 								// Capella shows a secret once only, so it is saved
 								// before the next key is created.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/user"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,11 +28,13 @@ import (
 	"github.com/couchbaselabs/cbdinocluster/utils/awscontrol"
 	"github.com/couchbaselabs/cbdinocluster/utils/azurecontrol"
 	"github.com/couchbaselabs/cbdinocluster/utils/caocontrol"
+	"github.com/couchbaselabs/cbdinocluster/utils/capellav4"
 	"github.com/couchbaselabs/cbdinocluster/utils/cloudinstancecontrol"
 	"github.com/couchbaselabs/cbdinocluster/utils/gcpcontrol"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/google/go-github/v53/github"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -1135,8 +1139,11 @@ var initCmd = &cobra.Command{
 		printCapellaConfig := func() {
 			fmt.Printf("  Enabled: %t\n", curConfig.Capella.Enabled.Value())
 			fmt.Printf("  V4 Endpoint: %s\n", curConfig.Capella.V4Endpoint)
-			fmt.Printf("  API Key: %s\n", curConfig.Capella.ApiKey)
-			fmt.Printf("  API Secret: %s\n", strings.Repeat("*", len(curConfig.Capella.ApiSecret)))
+			fmt.Printf("  API Keys: %d\n", len(curConfig.Capella.ApiKeys))
+			for _, apiKey := range curConfig.Capella.ApiKeys {
+				fmt.Printf("    %s: %s\n", apiKey.Key, strings.Repeat("*", len(apiKey.Secret)))
+			}
+			fmt.Printf("  Key Pool Name: %s\n", curConfig.Capella.PoolKeyName)
 			fmt.Printf("  Endpoint: %s\n", curConfig.Capella.Endpoint)
 			fmt.Printf("  Username: %s\n", curConfig.Capella.Username)
 			fmt.Printf("  Password: %s\n", strings.Repeat("*", len(curConfig.Capella.Password)))
@@ -1154,6 +1161,10 @@ var initCmd = &cobra.Command{
 			flagCapellaV4Endpoint, _ := cmd.Flags().GetString("capella-v4-endpoint")
 			flagCapellaApiKey, _ := cmd.Flags().GetString("capella-api-key")
 			flagCapellaApiSecret, _ := cmd.Flags().GetString("capella-api-secret")
+			flagCapellaCreatePool, _ := cmd.Flags().GetBool("capella-create-pool")
+			flagCapellaPoolName, _ := cmd.Flags().GetString("capella-pool-name")
+			flagCapellaPoolSize, _ := cmd.Flags().GetInt("capella-pool-size")
+			flagCapellaPoolExpiry, _ := cmd.Flags().GetFloat64("capella-pool-expiry")
 			flagCapellaEndpoint, _ := cmd.Flags().GetString("capella-endpoint")
 			flagCapellaUser, _ := cmd.Flags().GetString("capella-user")
 			flagCapellaPass, _ := cmd.Flags().GetString("capella-pass")
@@ -1177,8 +1188,15 @@ var initCmd = &cobra.Command{
 
 			capellaEnabled := curConfig.Capella.Enabled.ValueOr(true)
 			capellaV4Endpoint := curConfig.Capella.V4Endpoint
-			capellaApiKey := curConfig.Capella.ApiKey
-			capellaApiSecret := curConfig.Capella.ApiSecret
+			existingApiKeys := curConfig.Capella.ApiKeys
+			var capellaApiKey, capellaApiSecret string
+			if len(existingApiKeys) > 0 {
+				capellaApiKey = existingApiKeys[0].Key
+				capellaApiSecret = existingApiKeys[0].Secret
+			}
+			// Seeded so an early break (Capella disabled) keeps the saved keys.
+			capellaApiKeys := existingApiKeys
+			capellaPoolKeyName := curConfig.Capella.PoolKeyName
 			capellaEndpoint := curConfig.Capella.Endpoint
 			capellaUser := curConfig.Capella.Username
 			capellaPass := curConfig.Capella.Password
@@ -1260,58 +1278,27 @@ var initCmd = &cobra.Command{
 					continue
 				}
 
-				if flagCapellaEndpoint != "" {
-					fmt.Printf("Capella endpoint specified via flags:\n  %s\n", flagCapellaEndpoint)
-					capellaEndpoint = flagCapellaEndpoint
+				capellaApiKeys = []cbdcconfig.Config_CapellaApiKey{{
+					Key:    capellaApiKey,
+					Secret: capellaApiSecret,
+				}}
+
+				// Capella limits requests per key, so extra keys raise the budget.
+				if flagCapellaApiSecret != "" {
+					// The flag names only the primary key, so keep the rest of the saved pool.
+					if len(existingApiKeys) > 1 {
+						capellaApiKeys = appendApiKeys(capellaApiKeys, existingApiKeys[1:]...)
+					}
 				} else {
-					if capellaEndpoint == "" && envCapellaEndpoint != "" {
-						fmt.Printf("Defaulting to capella endpoint from environment.\n")
-						capellaEndpoint = envCapellaEndpoint
+					for i := 1; i < len(existingApiKeys); i++ {
+						savedApiKey := existingApiKeys[i]
+						// A named key belongs to the pool, which the pool section
+						// reconciles against Capella instead of asking here.
+						if savedApiKey.Name == "" && !readBool(keepApiKeyQuestion(i, savedApiKey), true) {
+							continue
+						}
+						capellaApiKeys = appendApiKeys(capellaApiKeys, savedApiKey)
 					}
-					if capellaEndpoint == "" {
-						capellaEndpoint = cbdcconfig.DEFAULT_CAPELLA_ENDPOINT
-					}
-
-					capellaEndpoint = readString(
-						"What Capella endpoint should we use?",
-						capellaEndpoint, false)
-				}
-				if capellaEndpoint == "" {
-					fmt.Printf("Capella endpoint is required.\n")
-					capellaEnabled = false
-					continue
-				}
-
-				if flagCapellaUser != "" {
-					fmt.Printf("Capella user specified via flags:\n  %s\n", flagCapellaUser)
-					capellaUser = flagCapellaUser
-				} else {
-					if capellaUser == "" && envCapellaUser != "" {
-						fmt.Printf("Defaulting to capella user from environment.\n")
-						capellaUser = envCapellaUser
-					}
-
-					capellaUser = readString(
-						"What Capella user should we use? (optional)",
-						capellaUser, false)
-				}
-
-				if flagCapellaPass != "" {
-					fmt.Printf("Capella pass specified via flags.\n")
-					capellaPass = flagCapellaPass
-				} else {
-					if capellaPass == "" && envCapellaPass != "" {
-						fmt.Printf("Defaulting to capella pass from environment.\n")
-						capellaPass = envCapellaPass
-					}
-
-					capellaPass = readString(
-						"What Capella pass should we use? (optional)",
-						capellaPass, true)
-				}
-				if capellaUser == "" || capellaPass == "" {
-					fmt.Printf("No Capella username and password specified.  Custom server images " +
-						"and columnar clusters will not be supported.\n")
 				}
 
 				if flagCapellaOid != "" {
@@ -1331,6 +1318,310 @@ var initCmd = &cobra.Command{
 					fmt.Printf("Capella oid is required.\n")
 					capellaEnabled = false
 					continue
+				}
+
+				// `init --auto` must stay free of Capella API calls and of key
+				// creation unless the pool was asked for, fit-cli depends on that.
+				for !autoConfig || flagCapellaCreatePool {
+					fmt.Printf("-- Capella API Key Pool\n")
+
+					poolName := capellaPoolKeyName
+					if poolName == "" {
+						poolName = curConfig.GitHub.User
+					}
+					if flagCapellaPoolName != "" {
+						fmt.Printf("Capella key pool name specified via flags:\n  %s\n", flagCapellaPoolName)
+						poolName = flagCapellaPoolName
+					} else {
+						poolName = readString(
+							"What name should identify this machine's Capella key pool? (empty skips pool management)",
+							poolName, false)
+					}
+					if poolName == "" {
+						fmt.Printf("No pool name given, skipping Capella API key pool management.\n")
+						break
+					}
+					capellaPoolKeyName = poolName
+
+					poolPrefix := capellaPoolKeyPrefix(poolName)
+					primaryKeyID := capellaApiKeys[0].Key
+
+					// Key management must not run over the round robin pool, a
+					// rotation there could invalidate a secret another request is
+					// using at that moment.
+					poolClient, err := capellav4.NewClient(&capellav4.ClientOptions{
+						Logger:     logger,
+						Endpoint:   capellaV4Endpoint,
+						SecretKeys: []string{capellaApiKeys[0].Secret},
+					})
+					if err != nil {
+						fmt.Printf("Skipping Capella API key pool management: %s\n", err)
+						break
+					}
+
+					fmt.Printf("Looking up the `%s*` keys in Capella... ", poolPrefix)
+					remoteKeys, err := poolClient.ListApiKeys(ctx, capellaOid)
+					if err != nil {
+						fmt.Printf("failed.\n")
+						fmt.Printf("Skipping Capella API key pool management, "+
+							"failed to list the Capella API keys:\n  %s\n", err)
+
+						var apiErr *capellav4.Error
+						if errors.As(err, &apiErr) && apiErr.HttpStatusCode == http.StatusForbidden {
+							fmt.Printf("The primary Capella API key needs the %s role to manage keys.\n",
+								capellav4.OrganizationRoleOwner)
+						}
+						break
+					}
+
+					poolKeys := partitionCapellaPoolKeys(poolPrefix, primaryKeyID,
+						capellaApiKeys, remoteKeys)
+					fmt.Printf("found %d.\n", len(poolKeys.Matched)+len(poolKeys.Orphans))
+
+					if len(poolKeys.Missing) > 0 {
+						droppedKeys := make(map[string]bool, len(poolKeys.Missing))
+						for _, missingKey := range poolKeys.Missing {
+							fmt.Printf("Dropping the saved Capella API key %s (%s), "+
+								"it no longer exists in Capella.\n", missingKey.Key, missingKey.Name)
+							droppedKeys[missingKey.Key] = true
+						}
+
+						keptKeys := make([]cbdcconfig.Config_CapellaApiKey, 0, len(capellaApiKeys))
+						for _, savedKey := range capellaApiKeys {
+							if droppedKeys[savedKey.Key] {
+								continue
+							}
+							keptKeys = append(keptKeys, savedKey)
+						}
+
+						capellaApiKeys = keptKeys
+					}
+
+					// The other Capella fields catch up at the final save, so a
+					// crash in here still keeps every secret Capella handed over.
+					savePoolKeys := func() {
+						curConfig.Capella.ApiKeys = capellaApiKeys
+						curConfig.Capella.PoolKeyName = capellaPoolKeyName
+						saveConfig()
+					}
+
+					if len(poolKeys.Orphans) > 0 {
+						fmt.Printf("Found %d Capella pool keys this machine holds no secret for.\n",
+							len(poolKeys.Orphans))
+
+						if readBool("Rotate them so this machine can use them?", true) {
+							for _, orphanKey := range poolKeys.Orphans {
+								err := checkCapellaPoolKeyTarget(poolPrefix, primaryKeyID,
+									orphanKey.ID, orphanKey.Name)
+								if err != nil {
+									fmt.Printf("%s\n", err)
+									continue
+								}
+
+								rotateResp, err := poolClient.RotateApiKey(ctx, capellaOid, orphanKey.ID)
+								if err != nil {
+									fmt.Printf("Failed to rotate the Capella API key %s:\n  %s\n",
+										orphanKey.ID, err)
+									continue
+								}
+
+								capellaApiKeys = append(capellaApiKeys,
+									cbdcconfig.Config_CapellaApiKey{
+										Key:    orphanKey.ID,
+										Secret: rotateResp.Token,
+										Name:   orphanKey.Name,
+									})
+								savePoolKeys()
+
+								fmt.Printf("Rotated the Capella API key %s (%s).\n",
+									orphanKey.ID, orphanKey.Name)
+							}
+						} else if readBool("Delete them from Capella instead?", false) {
+							for _, orphanKey := range poolKeys.Orphans {
+								err := checkCapellaPoolKeyTarget(poolPrefix, primaryKeyID,
+									orphanKey.ID, orphanKey.Name)
+								if err != nil {
+									fmt.Printf("%s\n", err)
+									continue
+								}
+
+								err = poolClient.DeleteApiKey(ctx, capellaOid, orphanKey.ID)
+								if err != nil {
+									fmt.Printf("Failed to delete the Capella API key %s:\n  %s\n",
+										orphanKey.ID, err)
+									continue
+								}
+
+								fmt.Printf("Deleted the Capella API key %s (%s).\n",
+									orphanKey.ID, orphanKey.Name)
+							}
+						} else {
+							fmt.Printf("Leaving those %d Capella pool keys as they are.\n",
+								len(poolKeys.Orphans))
+						}
+					}
+
+					shouldCreate := flagCapellaCreatePool
+					if shouldCreate {
+						fmt.Printf("Capella API key pool creation requested via flags.\n")
+					} else {
+						shouldCreate = readBool(
+							"Would you like cbdinocluster to create Capella API keys for the pool?",
+							false)
+					}
+
+					if shouldCreate {
+						poolExpiry := flagCapellaPoolExpiry
+						if cmd.Flags().Changed("capella-pool-expiry") {
+							fmt.Printf("Capella pool key expiry specified via flags:\n  %v days\n", poolExpiry)
+							// The API floors an expiry at 0.01 days, anything lower is a 422.
+							if poolExpiry != capellav4.ExpiryNever && poolExpiry < 0.01 {
+								fmt.Printf("Invalid Capella pool key expiry %v, it must be %d "+
+									"or at least 0.01 days.\n", poolExpiry, capellav4.ExpiryNever)
+								break
+							}
+						} else {
+							for {
+								expiryStr := readString(
+									"After how many days should a created pool key(s) expire? (-1 means never)",
+									strconv.FormatFloat(poolExpiry, 'f', -1, 64), false)
+
+								parsedExpiry, err := strconv.ParseFloat(expiryStr, 64)
+								if err != nil || (parsedExpiry != capellav4.ExpiryNever && parsedExpiry < 0.01) {
+									fmt.Printf("Invalid entry, it must be %d or at least 0.01 days, "+
+										"try again...\n", capellav4.ExpiryNever)
+									continue
+								}
+
+								poolExpiry = parsedExpiry
+								break
+							}
+						}
+
+						poolSize := flagCapellaPoolSize
+						for {
+							sizeStr := readString(
+								"How many Capella API keys should the pool hold?",
+								strconv.Itoa(poolSize), false)
+
+							parsedSize, err := strconv.Atoi(sizeStr)
+							if err != nil || parsedSize < 0 {
+								fmt.Printf("Invalid entry, try again...\n")
+								continue
+							}
+
+							poolSize = parsedSize
+							break
+						}
+
+						curPoolSize := countCapellaPoolKeys(poolPrefix, primaryKeyID, capellaApiKeys)
+						if curPoolSize >= poolSize {
+							fmt.Printf("The Capella API key pool already holds %d keys.\n", curPoolSize)
+						} else {
+							createFailed := false
+							createdKeys := 0
+
+							for curPoolSize+createdKeys < poolSize {
+								keyName, err := newCapellaPoolKeyName(poolName)
+								if err != nil {
+									fmt.Printf("Failed to name a Capella API key:\n  %s\n", err)
+									createFailed = true
+									break
+								}
+
+								createResp, err := poolClient.CreateApiKey(ctx, capellaOid,
+									&capellav4.CreateApiKeyRequest{
+										Name:              keyName,
+										Description:       capellaPoolKeyDescription(poolName),
+										Expiry:            poolExpiry,
+										OrganizationRoles: []string{capellav4.OrganizationRoleOwner},
+									})
+								if err != nil {
+									fmt.Printf("Failed to create a Capella API key:\n  %s\n", err)
+									createFailed = true
+									break
+								}
+
+								// Capella shows a secret once only, so it is saved
+								// before the next key is created.
+								capellaApiKeys = append(capellaApiKeys,
+									cbdcconfig.Config_CapellaApiKey{
+										Key:    createResp.ID,
+										Secret: createResp.Token,
+										Name:   keyName,
+									})
+								savePoolKeys()
+								createdKeys++
+
+								fmt.Printf("Created the Capella API key %s (%s).\n",
+									createResp.ID, keyName)
+							}
+
+							if createFailed {
+								fmt.Printf("Created %d of the %d keys the pool was missing.\n",
+									createdKeys, poolSize-curPoolSize)
+								break
+							}
+						}
+					}
+
+					fmt.Printf("The Capella API key pool holds %d keys.\n",
+						countCapellaPoolKeys(poolPrefix, primaryKeyID, capellaApiKeys))
+					break
+				}
+
+				if flagCapellaEndpoint != "" {
+					fmt.Printf("Capella endpoint specified via flags:\n  %s\n", flagCapellaEndpoint)
+					capellaEndpoint = flagCapellaEndpoint
+				} else {
+					if capellaEndpoint == "" && envCapellaEndpoint != "" {
+						fmt.Printf("Defaulting to capella endpoint from environment.\n")
+						capellaEndpoint = envCapellaEndpoint
+					}
+					if capellaEndpoint == "" {
+						capellaEndpoint = cbdcconfig.DEFAULT_CAPELLA_ENDPOINT
+					}
+
+					capellaEndpoint = readString(
+						"What Capella v2 endpoint should we use?",
+						capellaEndpoint, false)
+				}
+				if capellaEndpoint == "" {
+					fmt.Printf("Capella endpoint is required.\n")
+					capellaEnabled = false
+					continue
+				}
+
+				if flagCapellaUser != "" {
+					fmt.Printf("Capella user specified via flags:\n  %s\n", flagCapellaUser)
+					capellaUser = flagCapellaUser
+				} else {
+					if capellaUser == "" && envCapellaUser != "" {
+						fmt.Printf("Defaulting to capella user from environment.\n")
+						capellaUser = envCapellaUser
+					}
+
+					capellaUser = readString(
+						"What Capella v2 user should we use? (optional)",
+						capellaUser, false)
+				}
+
+				if flagCapellaPass != "" {
+					fmt.Printf("Capella pass specified via flags.\n")
+					capellaPass = flagCapellaPass
+				} else {
+					if capellaPass == "" && envCapellaPass != "" {
+						fmt.Printf("Defaulting to capella pass from environment.\n")
+						capellaPass = envCapellaPass
+					}
+
+					capellaPass = readString(
+						"What Capella v2 pass should we use? (optional)",
+						capellaPass, true)
+				}
+				if capellaUser == "" || capellaPass == "" {
+					fmt.Printf("No Capella username and password specified.  Custom server images " +
+						"and columnar clusters will not be supported.\n")
 				}
 
 				if flagCapellaOverrideToken != "" {
@@ -1475,8 +1766,8 @@ var initCmd = &cobra.Command{
 
 			curConfig.Capella.Enabled.Set(capellaEnabled)
 			curConfig.Capella.V4Endpoint = capellaV4Endpoint
-			curConfig.Capella.ApiKey = capellaApiKey
-			curConfig.Capella.ApiSecret = capellaApiSecret
+			curConfig.Capella.ApiKeys = capellaApiKeys
+			curConfig.Capella.PoolKeyName = capellaPoolKeyName
 			curConfig.Capella.Endpoint = capellaEndpoint
 			curConfig.Capella.Username = capellaUser
 			curConfig.Capella.Password = capellaPass
@@ -1653,6 +1944,42 @@ var initCmd = &cobra.Command{
 	},
 }
 
+// appendApiKeys adds the keys whose secret is set and not already in the pool.
+func appendApiKeys(pool []cbdcconfig.Config_CapellaApiKey,
+	extra ...cbdcconfig.Config_CapellaApiKey) []cbdcconfig.Config_CapellaApiKey {
+	usedSecrets := make(map[string]bool, len(pool))
+	for _, apiKey := range pool {
+		usedSecrets[apiKey.Secret] = true
+	}
+
+	for _, apiKey := range extra {
+		if apiKey.Secret == "" || usedSecrets[apiKey.Secret] {
+			continue
+		}
+		usedSecrets[apiKey.Secret] = true
+
+		pool = append(pool, apiKey)
+	}
+
+	return pool
+}
+
+func keepApiKeyQuestion(index int, apiKey cbdcconfig.Config_CapellaApiKey) string {
+	var details []string
+	if apiKey.Key != "" {
+		details = append(details, apiKey.Key)
+	}
+	if apiKey.Name != "" {
+		details = append(details, apiKey.Name)
+	}
+
+	if len(details) == 0 {
+		return fmt.Sprintf("Keep the saved Capella API key #%d?", index+1)
+	}
+	return fmt.Sprintf("Keep the saved Capella API key #%d (%s)?",
+		index+1, strings.Join(details, ", "))
+}
+
 func init() {
 	rootCmd.AddCommand(initCmd)
 
@@ -1672,6 +1999,11 @@ func init() {
 	initCmd.Flags().String("capella-v4-endpoint", "", "Capella Management API v4 endpoint to use")
 	initCmd.Flags().String("capella-api-key", "", "Capella organization API key to use")
 	initCmd.Flags().String("capella-api-secret", "", "Capella organization API secret to use")
+	initCmd.Flags().Bool("capella-create-pool", false, "Create the Capella API keys the key pool is missing")
+	initCmd.Flags().String("capella-pool-name", "", "Name that identifies this machine's Capella API key pool")
+	initCmd.Flags().Int("capella-pool-size", 10, "Number of Capella API keys the key pool should hold")
+	initCmd.Flags().Float64("capella-pool-expiry", 0.5,
+		"Days until a created pool key expires, -1 means never")
 	initCmd.Flags().String("capella-endpoint", "", "Capella v2 endpoint to use")
 	initCmd.Flags().String("capella-user", "", "Capella v2 user to use, only needed for features the v4 api does not expose")
 	initCmd.Flags().String("capella-pass", "", "Capella v2 pass to use, only needed for features the v4 api does not expose")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
 	"github.com/couchbaselabs/cbdinocluster/utils/capellav4"
@@ -107,11 +109,21 @@ type fakeCapellaApiKeys struct {
 	keys         []*capellav4.ApiKeyInfo
 	failCreateAt int
 
+	// rateLimitFirstCreates answers 429 to that many create requests, then lets
+	// the pool grow. rateLimitPastCreates answers 429 to every create request
+	// once that many creates succeeded. retryAfter is sent with each 429.
+	rateLimitFirstCreates int
+	rateLimitPastCreates  int
+	retryAfter            string
+
 	requests       int
 	creates        int
+	created        int
 	createExpiries []float64
+	createAuths    []string
 	rotated        []string
 	deleted        []string
+	deleteAuths    map[string]string
 }
 
 func (f *fakeCapellaApiKeys) start(t *testing.T) string {
@@ -139,6 +151,18 @@ func (f *fakeCapellaApiKeys) start(t *testing.T) string {
 
 		case r.Method == http.MethodPost && subPath == "":
 			f.creates++
+			f.createAuths = append(f.createAuths, r.Header.Get("Authorization"))
+
+			if f.creates <= f.rateLimitFirstCreates ||
+				(f.rateLimitPastCreates > 0 && f.created >= f.rateLimitPastCreates) {
+				if f.retryAfter != "" {
+					w.Header().Set("Retry-After", f.retryAfter)
+				}
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+				return
+			}
+
 			if f.creates == f.failCreateAt {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write([]byte(`{"code":4000,"httpStatusCode":422,"message":"key limit reached"}`))
@@ -149,7 +173,8 @@ func (f *fakeCapellaApiKeys) start(t *testing.T) string {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			f.createExpiries = append(f.createExpiries, req.Expiry)
 
-			keyID := fmt.Sprintf("created-%d", f.creates)
+			f.created++
+			keyID := fmt.Sprintf("created-%d", f.created)
 			f.keys = append(f.keys, &capellav4.ApiKeyInfo{ID: keyID, Name: req.Name})
 
 			w.WriteHeader(http.StatusCreated)
@@ -163,7 +188,12 @@ func (f *fakeCapellaApiKeys) start(t *testing.T) string {
 				"secretKey": keyID, "token": "rotated-" + keyID})
 
 		case r.Method == http.MethodDelete && subPath != "":
-			f.deleted = append(f.deleted, strings.TrimPrefix(subPath, "/"))
+			keyID := strings.TrimPrefix(subPath, "/")
+			f.deleted = append(f.deleted, keyID)
+			if f.deleteAuths == nil {
+				f.deleteAuths = make(map[string]string)
+			}
+			f.deleteAuths[keyID] = r.Header.Get("Authorization")
 			w.WriteHeader(http.StatusNoContent)
 
 		default:
@@ -203,6 +233,18 @@ func (f *fakeCapellaApiKeys) deletedKeys() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.deleted...)
+}
+
+func (f *fakeCapellaApiKeys) createAuthorizations() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.createAuths...)
+}
+
+func (f *fakeCapellaApiKeys) deleteAuthorizations() map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return maps.Clone(f.deleteAuths)
 }
 
 func writeTestConfig(t *testing.T, config *cbdcconfig.Config) string {
@@ -423,4 +465,175 @@ func TestInitRotatesPoolKeysWithNoSavedSecret(t *testing.T) {
 		{Key: "primary", Secret: "primary-secret"},
 		{Key: "pool-orphan", Secret: "rotated-pool-orphan", Name: "cbdino_pool_test_aaaaaaaa"},
 	}, savedConfig.Capella.ApiKeys)
+}
+
+// sleepRecorder stands in for the rate limit wait, so a test can check the
+// delay without spending it.
+type sleepRecorder struct {
+	mu    sync.Mutex
+	waits []time.Duration
+}
+
+func (s *sleepRecorder) sleep(wait time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.waits = append(s.waits, wait)
+}
+
+func (s *sleepRecorder) recorded() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]time.Duration(nil), s.waits...)
+}
+
+func recordCapellaPoolKeyWaits(t *testing.T) *sleepRecorder {
+	t.Helper()
+
+	recorder := &sleepRecorder{}
+	previousSleep := capellaPoolKeySleep
+	capellaPoolKeySleep = recorder.sleep
+	t.Cleanup(func() { capellaPoolKeySleep = previousSleep })
+
+	return recorder
+}
+
+// runTestCloudApiKeysRemove drives the real remove command against a throwaway
+// config, with the same isolation runTestInit uses.
+func runTestCloudApiKeysRemove(t *testing.T, configPath string, args ...string) {
+	t.Helper()
+
+	t.Setenv(cbdcconfig.EnvConfigPath, configPath)
+	for _, envName := range []string{
+		"CAPELLA_V4_ENDPOINT", "CAPELLA_API_KEY", "CAPELLA_API_SECRET",
+		"CAPELLA_ENDPOINT", "CAPELLA_USER", "CAPELLA_PASS",
+		"CAPELLA_OID", "CAPELLA_OVERRIDE_TOKEN", "CAPELLA_INTERNAL_SUPPORT_TOKEN",
+	} {
+		t.Setenv(envName, "")
+	}
+
+	t.Cleanup(func() {
+		cbdcconfig.SetConfigPathOverride("")
+		rootCmd.SetArgs(nil)
+	})
+
+	cmdArgs := []string{"cloud", "apikeys", "remove", "--config", configPath}
+	cmdArgs = append(cmdArgs, args...)
+
+	rootCmd.SetArgs(cmdArgs)
+	require.NoError(t, rootCmd.Execute())
+}
+
+// A created key joins the ring at once, so the creates that follow spread over
+// the pool instead of spending the primary key's whole rate budget.
+func TestInitGrowsTheRingOnCreate(t *testing.T) {
+	fake := &fakeCapellaApiKeys{}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, ""))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-name=test",
+		"--capella-pool-size=3")
+
+	createAuths := fake.createAuthorizations()
+	require.Len(t, createAuths, 3)
+
+	createdTokens := map[string]bool{
+		"Bearer secret-created-1": true,
+		"Bearer secret-created-2": true,
+	}
+	usedCreated := false
+	for _, auth := range createAuths[1:] {
+		if createdTokens[auth] {
+			usedCreated = true
+		}
+	}
+	assert.True(t, usedCreated,
+		"a create after the first must ride a created pool key, got %v", createAuths)
+}
+
+// Pool creation is the one call that waits, because a fresh machine holds the
+// primary key alone and a whole ring can be busy at the same time.
+func TestInitCreateWaitsOutARateLimitedRing(t *testing.T) {
+	recorder := recordCapellaPoolKeyWaits(t)
+
+	fake := &fakeCapellaApiKeys{rateLimitFirstCreates: 2, retryAfter: "7"}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, ""))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-name=test",
+		"--capella-pool-size=1")
+
+	assert.Equal(t, []time.Duration{7 * time.Second, 7 * time.Second}, recorder.recorded())
+	assert.Equal(t, 3, fake.createCount())
+
+	savedConfig := readTestConfig(t, configPath)
+	require.Len(t, savedConfig.Capella.ApiKeys, 2)
+	assert.Equal(t, "created-1", savedConfig.Capella.ApiKeys[1].Key)
+	assert.Equal(t, "secret-created-1", savedConfig.Capella.ApiKeys[1].Secret)
+}
+
+// A ring that stays rate limited must give up, so init cannot hang a job.
+func TestInitCreateFailsAfterThreeWaits(t *testing.T) {
+	recorder := recordCapellaPoolKeyWaits(t)
+
+	fake := &fakeCapellaApiKeys{rateLimitPastCreates: 1, retryAfter: "7"}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, ""))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-name=test",
+		"--capella-pool-size=2")
+
+	assert.Equal(t, []time.Duration{7 * time.Second, 7 * time.Second, 7 * time.Second},
+		recorder.recorded())
+	// One create succeeds, then the second one sweeps a two key ring four times.
+	assert.Equal(t, 9, fake.createCount())
+
+	savedConfig := readTestConfig(t, configPath)
+	require.Len(t, savedConfig.Capella.ApiKeys, 2)
+	assert.Equal(t, "primary", savedConfig.Capella.ApiKeys[0].Key)
+	assert.Equal(t, "created-1", savedConfig.Capella.ApiKeys[1].Key)
+	assert.Equal(t, "secret-created-1", savedConfig.Capella.ApiKeys[1].Secret)
+}
+
+// A deleted key cannot authorize anything, so its own secret must leave the
+// ring before the delete request goes out.
+func TestCloudApiKeysRemoveNeverSelfAuthorizesADelete(t *testing.T) {
+	fake := &fakeCapellaApiKeys{keys: []*capellav4.ApiKeyInfo{
+		{ID: "primary", Name: "a hand made key"},
+		{ID: "pool-one", Name: "cbdino_pool_test_aaaaaaaa"},
+		{ID: "pool-two", Name: "cbdino_pool_test_bbbbbbbb"},
+	}}
+	endpoint := fake.start(t)
+
+	config := testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-one", Secret: "pool-one-secret", Name: "cbdino_pool_test_aaaaaaaa"},
+		{Key: "pool-two", Secret: "pool-two-secret", Name: "cbdino_pool_test_bbbbbbbb"},
+	}, "test")
+	config.Capella.V4Endpoint = endpoint
+	configPath := writeTestConfig(t, config)
+
+	runTestCloudApiKeysRemove(t, configPath)
+
+	assert.ElementsMatch(t, []string{"pool-one", "pool-two"}, fake.deletedKeys())
+
+	deleteAuths := fake.deleteAuthorizations()
+	require.Contains(t, deleteAuths, "pool-one")
+	require.Contains(t, deleteAuths, "pool-two")
+	assert.NotEqual(t, "Bearer pool-one-secret", deleteAuths["pool-one"])
+	assert.NotEqual(t, "Bearer pool-two-secret", deleteAuths["pool-two"])
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,426 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/couchbaselabs/cbdinocluster/cbdcconfig"
+	"github.com/couchbaselabs/cbdinocluster/utils/capellav4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestAppendApiKeys covers the dedup that every branch of init relies on, so a
+// rerun cannot shrink the pool by re-adding a secret it already holds.
+func TestAppendApiKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		pool  []cbdcconfig.Config_CapellaApiKey
+		extra []cbdcconfig.Config_CapellaApiKey
+		want  []cbdcconfig.Config_CapellaApiKey
+	}{
+		{
+			name: "empty secret skipped",
+			extra: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: ""},
+				{Key: "id-two", Secret: "secret-two"},
+			},
+			want: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-two", Secret: "secret-two"},
+			},
+		},
+		{
+			name: "secret already in the pool skipped",
+			pool: []cbdcconfig.Config_CapellaApiKey{{Key: "primary", Secret: "secret-one"}},
+			extra: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: "secret-one"},
+				{Key: "id-two", Secret: "secret-two"},
+			},
+			want: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "primary", Secret: "secret-one"},
+				{Key: "id-two", Secret: "secret-two"},
+			},
+		},
+		{
+			name: "duplicate inside extra skipped",
+			extra: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: "secret-one"},
+				{Key: "id-two", Secret: "secret-one"},
+			},
+			want: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: "secret-one"},
+			},
+		},
+		{
+			name: "same secret under two ids kept once",
+			pool: []cbdcconfig.Config_CapellaApiKey{{Key: "id-one", Secret: "secret-one"}},
+			extra: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one-renamed", Secret: "secret-one"},
+			},
+			want: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: "secret-one"},
+			},
+		},
+		{
+			name: "nothing to add",
+			pool: []cbdcconfig.Config_CapellaApiKey{{Key: "id-one", Secret: "secret-one"}},
+			want: []cbdcconfig.Config_CapellaApiKey{
+				{Key: "id-one", Secret: "secret-one"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendApiKeys(tt.pool, tt.extra...)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKeepApiKeyQuestion(t *testing.T) {
+	require.Equal(t, "Keep the saved Capella API key #2 (id-two)?",
+		keepApiKeyQuestion(1, cbdcconfig.Config_CapellaApiKey{Key: "id-two", Secret: "secret-two"}))
+	require.Equal(t, "Keep the saved Capella API key #2?",
+		keepApiKeyQuestion(1, cbdcconfig.Config_CapellaApiKey{Secret: "secret-two"}))
+	require.Equal(t, "Keep the saved Capella API key #2 (id-two, cbdino_pool_test_aaaaaaaa)?",
+		keepApiKeyQuestion(1, cbdcconfig.Config_CapellaApiKey{
+			Key: "id-two", Secret: "secret-two", Name: "cbdino_pool_test_aaaaaaaa"}))
+	require.Equal(t, "Keep the saved Capella API key #2 (cbdino_pool_test_aaaaaaaa)?",
+		keepApiKeyQuestion(1, cbdcconfig.Config_CapellaApiKey{
+			Secret: "secret-two", Name: "cbdino_pool_test_aaaaaaaa"}))
+}
+
+// fakeCapellaApiKeys serves the v4 API key endpoints the init pool section
+// uses, so no test ever reaches the real Capella API.
+type fakeCapellaApiKeys struct {
+	mu sync.Mutex
+
+	keys         []*capellav4.ApiKeyInfo
+	failCreateAt int
+
+	requests       int
+	creates        int
+	createExpiries []float64
+	rotated        []string
+	deleted        []string
+}
+
+func (f *fakeCapellaApiKeys) start(t *testing.T) string {
+	t.Helper()
+
+	const basePath = "/v4/organizations/org/apikeys"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.requests++
+
+		if !strings.HasPrefix(r.URL.Path, basePath) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		subPath := strings.TrimPrefix(r.URL.Path, basePath)
+
+		switch {
+		case r.Method == http.MethodGet && subPath == "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": f.keys,
+				"cursor": map[string]any{"pages": map[string]any{
+					"page": 1, "last": 1, "perPage": 100, "totalItems": len(f.keys)}},
+			})
+
+		case r.Method == http.MethodPost && subPath == "":
+			f.creates++
+			if f.creates == f.failCreateAt {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"code":4000,"httpStatusCode":422,"message":"key limit reached"}`))
+				return
+			}
+
+			var req capellav4.CreateApiKeyRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			f.createExpiries = append(f.createExpiries, req.Expiry)
+
+			keyID := fmt.Sprintf("created-%d", f.creates)
+			f.keys = append(f.keys, &capellav4.ApiKeyInfo{ID: keyID, Name: req.Name})
+
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"id": keyID, "token": "secret-" + keyID})
+
+		case r.Method == http.MethodPost && strings.HasSuffix(subPath, "/rotate"):
+			keyID := strings.TrimSuffix(strings.TrimPrefix(subPath, "/"), "/rotate")
+			f.rotated = append(f.rotated, keyID)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"secretKey": keyID, "token": "rotated-" + keyID})
+
+		case r.Method == http.MethodDelete && subPath != "":
+			f.deleted = append(f.deleted, strings.TrimPrefix(subPath, "/"))
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+func (f *fakeCapellaApiKeys) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.requests
+}
+
+func (f *fakeCapellaApiKeys) createCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.creates
+}
+
+func (f *fakeCapellaApiKeys) createdExpiries() []float64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]float64(nil), f.createExpiries...)
+}
+
+func (f *fakeCapellaApiKeys) rotatedKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.rotated...)
+}
+
+func (f *fakeCapellaApiKeys) deletedKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.deleted...)
+}
+
+func writeTestConfig(t *testing.T, config *cbdcconfig.Config) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "cbdinocluster.yaml")
+	configBytes, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, configBytes, 0600))
+
+	return configPath
+}
+
+func readTestConfig(t *testing.T, configPath string) *cbdcconfig.Config {
+	t.Helper()
+
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var config *cbdcconfig.Config
+	require.NoError(t, yaml.Unmarshal(configBytes, &config))
+
+	return config
+}
+
+// runTestInit drives the real init command with every non Capella provider
+// disabled. The config path override and CBDINOCLUSTER_CONFIG both point at a
+// throwaway file, so the developer's own config is never touched.
+func runTestInit(t *testing.T, configPath, v4Endpoint string, poolArgs ...string) {
+	t.Helper()
+
+	t.Setenv(cbdcconfig.EnvConfigPath, configPath)
+	for _, envName := range []string{
+		"CAPELLA_V4_ENDPOINT", "CAPELLA_API_KEY", "CAPELLA_API_SECRET",
+		"CAPELLA_ENDPOINT", "CAPELLA_USER", "CAPELLA_PASS",
+		"CAPELLA_OID", "CAPELLA_OVERRIDE_TOKEN", "CAPELLA_INTERNAL_SUPPORT_TOKEN",
+	} {
+		t.Setenv(envName, "")
+	}
+
+	t.Cleanup(func() {
+		cbdcconfig.SetConfigPathOverride("")
+		rootCmd.SetArgs(nil)
+	})
+
+	// Cobra flags are process globals, so a value set by one Execute leaks into
+	// the next. The expiry flag is the only pool flag the base args leave unset.
+	expiryFlag := initCmd.Flags().Lookup("capella-pool-expiry")
+	require.NotNil(t, expiryFlag)
+	require.NoError(t, expiryFlag.Value.Set(expiryFlag.DefValue))
+	expiryFlag.Changed = false
+
+	args := []string{"init", "--auto",
+		"--config", configPath,
+		"--disable-github", "--disable-docker", "--disable-k8s",
+		"--disable-aws", "--disable-azure", "--disable-gcp", "--disable-dns",
+		"--capella-v4-endpoint", v4Endpoint,
+		"--capella-create-pool=false",
+		"--capella-pool-name=",
+		"--capella-pool-size=10",
+	}
+	args = append(args, poolArgs...)
+
+	rootCmd.SetArgs(args)
+	require.NoError(t, rootCmd.Execute())
+}
+
+func testCapellaConfig(apiKeys []cbdcconfig.Config_CapellaApiKey, poolName string) *cbdcconfig.Config {
+	config := &cbdcconfig.Config{Version: cbdcconfig.Version}
+	config.Capella.Enabled.Set(true)
+	config.Capella.ApiKeys = apiKeys
+	config.Capella.PoolKeyName = poolName
+	config.Capella.OrganizationID = "org"
+	config.Capella.Endpoint = cbdcconfig.DEFAULT_CAPELLA_ENDPOINT
+	config.Capella.DefaultCloud = cbdcconfig.DEFAULT_CAPELLA_PROVIDER
+	config.Capella.DefaultAwsRegion = cbdcconfig.DEFAULT_AWS_REGION
+	config.Capella.DefaultAzureRegion = cbdcconfig.DEFAULT_AZURE_REGION
+	config.Capella.DefaultGcpRegion = cbdcconfig.DEFAULT_GCP_REGION
+	return config
+}
+
+// fit-cli runs `init --auto` on every job, so it must reproduce the saved keys
+// without spending a single Capella API call.
+func TestInitAutoLeavesTheSavedPoolAlone(t *testing.T) {
+	fake := &fakeCapellaApiKeys{}
+	endpoint := fake.start(t)
+
+	savedApiKeys := []cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-one", Secret: "pool-one-secret", Name: "cbdino_pool_test_aaaaaaaa"},
+		{Key: "pool-two", Secret: "pool-two-secret", Name: "cbdino_pool_test_bbbbbbbb"},
+	}
+	configPath := writeTestConfig(t, testCapellaConfig(savedApiKeys, "test"))
+
+	runTestInit(t, configPath, endpoint)
+
+	assert.Equal(t, 0, fake.requestCount(), "init --auto must not call the Capella API")
+
+	savedConfig := readTestConfig(t, configPath)
+	assert.Equal(t, savedApiKeys, savedConfig.Capella.ApiKeys)
+	assert.Equal(t, "test", savedConfig.Capella.PoolKeyName)
+}
+
+// Capella returns a secret once only, so every created key must reach the disk
+// before the next one is created.
+func TestInitCreatesPoolKeysAndSavesEachSecret(t *testing.T) {
+	fake := &fakeCapellaApiKeys{failCreateAt: 3}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, ""))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-name=test",
+		"--capella-pool-size=3",
+		"--capella-pool-expiry=1")
+
+	savedConfig := readTestConfig(t, configPath)
+	assert.Equal(t, "test", savedConfig.Capella.PoolKeyName)
+	assert.Equal(t, 3, fake.createCount(), "init must ask for the three missing keys")
+	// The failing third create is refused before its body is read.
+	assert.Equal(t, []float64{1, 1}, fake.createdExpiries())
+
+	// The third create failed, so only the first two secrets exist at all.
+	require.Len(t, savedConfig.Capella.ApiKeys, 3)
+	assert.Equal(t, "primary", savedConfig.Capella.ApiKeys[0].Key)
+	assert.Equal(t, "created-1", savedConfig.Capella.ApiKeys[1].Key)
+	assert.Equal(t, "secret-created-1", savedConfig.Capella.ApiKeys[1].Secret)
+	assert.Equal(t, "created-2", savedConfig.Capella.ApiKeys[2].Key)
+	assert.Equal(t, "secret-created-2", savedConfig.Capella.ApiKeys[2].Secret)
+
+	for _, createdKey := range savedConfig.Capella.ApiKeys[1:] {
+		assert.True(t, strings.HasPrefix(createdKey.Name, "cbdino_pool_test_"),
+			"created key %s has no pool name", createdKey.Key)
+	}
+}
+
+// A machine with no pool name yet names its pool after the GitHub user, so the
+// keys it creates carry an owner anyone can read in the Capella UI.
+func TestInitNamesThePoolAfterTheGitHubUser(t *testing.T) {
+	fake := &fakeCapellaApiKeys{}
+	endpoint := fake.start(t)
+
+	config := testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, "")
+	config.GitHub.User = "ghuser"
+	configPath := writeTestConfig(t, config)
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-size=1")
+
+	savedConfig := readTestConfig(t, configPath)
+	assert.Equal(t, "ghuser", savedConfig.Capella.PoolKeyName)
+	assert.Equal(t, []float64{0.5}, fake.createdExpiries(),
+		"a key created without the expiry flag must default to half a day")
+
+	require.Len(t, savedConfig.Capella.ApiKeys, 2)
+	assert.True(t, strings.HasPrefix(savedConfig.Capella.ApiKeys[1].Name, "cbdino_pool_ghuser_"),
+		"created key %s has no pool name", savedConfig.Capella.ApiKeys[1].Key)
+}
+
+// A key deleted in the Capella UI leaves a secret that cannot work any more.
+func TestInitDropsPoolKeysCapellaNoLongerLists(t *testing.T) {
+	fake := &fakeCapellaApiKeys{keys: []*capellav4.ApiKeyInfo{
+		{ID: "primary", Name: "a hand made key"},
+		{ID: "pool-one", Name: "cbdino_pool_test_aaaaaaaa"},
+	}}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-one", Secret: "pool-one-secret", Name: "cbdino_pool_test_aaaaaaaa"},
+		{Key: "pool-gone", Secret: "pool-gone-secret", Name: "cbdino_pool_test_bbbbbbbb"},
+	}, "test"))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-size=1")
+
+	savedConfig := readTestConfig(t, configPath)
+	assert.Equal(t, []cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-one", Secret: "pool-one-secret", Name: "cbdino_pool_test_aaaaaaaa"},
+	}, savedConfig.Capella.ApiKeys)
+
+	assert.Empty(t, fake.rotatedKeys())
+	assert.Empty(t, fake.deletedKeys())
+	assert.Equal(t, 0, fake.createCount(), "the pool already holds the requested number of keys")
+}
+
+// The v4 API never gives a secret back, so a pool key this machine lost the
+// secret of is only usable again after a rotation.
+func TestInitRotatesPoolKeysWithNoSavedSecret(t *testing.T) {
+	fake := &fakeCapellaApiKeys{keys: []*capellav4.ApiKeyInfo{
+		{ID: "primary", Name: "a hand made key"},
+		{ID: "pool-orphan", Name: "cbdino_pool_test_aaaaaaaa"},
+	}}
+	endpoint := fake.start(t)
+
+	configPath := writeTestConfig(t, testCapellaConfig([]cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+	}, "test"))
+
+	runTestInit(t, configPath, endpoint,
+		"--capella-create-pool=true",
+		"--capella-pool-size=1")
+
+	assert.Equal(t, []string{"pool-orphan"}, fake.rotatedKeys())
+	assert.Empty(t, fake.deletedKeys())
+	assert.Equal(t, 0, fake.createCount())
+
+	savedConfig := readTestConfig(t, configPath)
+	assert.Equal(t, []cbdcconfig.Config_CapellaApiKey{
+		{Key: "primary", Secret: "primary-secret"},
+		{Key: "pool-orphan", Secret: "rotated-pool-orphan", Name: "cbdino_pool_test_aaaaaaaa"},
+	}, savedConfig.Capella.ApiKeys)
+}

--- a/utils/capellav4/apikeys.go
+++ b/utils/capellav4/apikeys.go
@@ -1,0 +1,80 @@
+package capellav4
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const OrganizationRoleOwner = "organizationOwner"
+
+// ExpiryNever keeps a key valid until it is deleted.
+const ExpiryNever = -1
+
+type ApiKeyInfo struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	Expiry            float64  `json:"expiry"`
+	AllowedCIDRs      []string `json:"allowedCIDRs"`
+	OrganizationRoles []string `json:"organizationRoles"`
+	Audit             Audit    `json:"audit"`
+}
+
+func (c *Client) ListApiKeys(ctx context.Context, orgID string) ([]*ApiKeyInfo, error) {
+	path := fmt.Sprintf("/v4/organizations/%s/apikeys", orgID)
+	return listAll[*ApiKeyInfo](ctx, c, path, nil)
+}
+
+type CreateApiKeyRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Days until the key expires, or ExpiryNever. Omitting it means 180 days,
+	// so callers that want a lasting key must set it.
+	Expiry            float64  `json:"expiry,omitempty"`
+	OrganizationRoles []string `json:"organizationRoles"`
+}
+
+type CreateApiKeyResponse struct {
+	ID    string `json:"id"`
+	Token string `json:"token"`
+}
+
+// Token is the bearer secret and Capella returns it here only. A caller that
+// loses it can only rotate the key to get a new one.
+func (c *Client) CreateApiKey(
+	ctx context.Context,
+	orgID string,
+	req *CreateApiKeyRequest,
+) (*CreateApiKeyResponse, error) {
+	resp := &CreateApiKeyResponse{}
+	path := fmt.Sprintf("/v4/organizations/%s/apikeys", orgID)
+	if err := c.doWrite(ctx, http.MethodPost, path, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) DeleteApiKey(ctx context.Context, orgID, keyID string) error {
+	path := fmt.Sprintf("/v4/organizations/%s/apikeys/%s", orgID, keyID)
+	return c.doWrite(ctx, http.MethodDelete, path, nil, nil)
+}
+
+type RotateApiKeyResponse struct {
+	SecretKey string `json:"secretKey"`
+	Token     string `json:"token"`
+}
+
+// Rotation replaces the bearer secret, so any client still holding the old
+// token stops working right away.
+func (c *Client) RotateApiKey(
+	ctx context.Context,
+	orgID, keyID string,
+) (*RotateApiKeyResponse, error) {
+	resp := &RotateApiKeyResponse{}
+	path := fmt.Sprintf("/v4/organizations/%s/apikeys/%s/rotate", orgID, keyID)
+	if err := c.doWrite(ctx, http.MethodPost, path, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/utils/capellav4/apikeys_test.go
+++ b/utils/capellav4/apikeys_test.go
@@ -1,0 +1,178 @@
+package capellav4
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListApiKeysFollowsEveryPage(t *testing.T) {
+	const totalItems = 150
+
+	var requests atomic.Int32
+	var gotPath, gotAuth string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		perPage, err := strconv.Atoi(r.URL.Query().Get("perPage"))
+		require.NoError(t, err)
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		require.NoError(t, err)
+
+		lastPage := (totalItems + perPage - 1) / perPage
+
+		var data []*ApiKeyInfo
+		start := (page - 1) * perPage
+		for i := start; i < start+perPage && i < totalItems; i++ {
+			data = append(data, &ApiKeyInfo{
+				ID:                strconv.Itoa(i),
+				Name:              "cbdino_pool_test_" + strconv.Itoa(i),
+				Expiry:            ExpiryNever,
+				OrganizationRoles: []string{OrganizationRoleOwner},
+			})
+		}
+
+		_ = json.NewEncoder(w).Encode(pagedResponse[*ApiKeyInfo]{
+			Data:   data,
+			Cursor: cursor{Pages: pageInfo{Page: page, PerPage: perPage, Last: lastPage, TotalItems: totalItems}},
+		})
+	}))
+
+	apiKeys, err := client.ListApiKeys(context.Background(), "org")
+	require.NoError(t, err)
+
+	require.Len(t, apiKeys, totalItems)
+	assert.Equal(t, "/v4/organizations/org/apikeys", gotPath)
+	assert.Equal(t, "Bearer test-secret", gotAuth)
+	assert.Equal(t, "0", apiKeys[0].ID)
+	assert.Equal(t, "cbdino_pool_test_0", apiKeys[0].Name)
+	assert.Equal(t, float64(-1), apiKeys[0].Expiry)
+	assert.Equal(t, []string{OrganizationRoleOwner}, apiKeys[0].OrganizationRoles)
+	assert.Equal(t, "149", apiKeys[totalItems-1].ID)
+	assert.Equal(t, int32(2), requests.Load())
+}
+
+func TestListApiKeysDecodesEveryField(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{
+			"id":"key-1",
+			"name":"cbdino_pool_dev_abcd1234",
+			"description":"Created by cbdinocluster",
+			"expiry":-1,
+			"allowedCIDRs":["0.0.0.0/0"],
+			"organizationRoles":["organizationOwner"],
+			"audit":{"createdBy":"someone","createdAt":"2026-01-01T00:00:00Z","version":1}
+		}],"cursor":{"pages":{"page":1,"last":1,"perPage":100,"totalItems":1}}}`))
+	}))
+
+	apiKeys, err := client.ListApiKeys(context.Background(), "org")
+	require.NoError(t, err)
+
+	require.Len(t, apiKeys, 1)
+	assert.Equal(t, "key-1", apiKeys[0].ID)
+	assert.Equal(t, "cbdino_pool_dev_abcd1234", apiKeys[0].Name)
+	assert.Equal(t, "Created by cbdinocluster", apiKeys[0].Description)
+	assert.Equal(t, []string{"0.0.0.0/0"}, apiKeys[0].AllowedCIDRs)
+	assert.Equal(t, "someone", apiKeys[0].Audit.CreatedBy)
+}
+
+func TestCreateApiKey(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var body map[string]any
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"key-1","token":"the-secret"}`))
+	}))
+
+	resp, err := client.CreateApiKey(context.Background(), "org", &CreateApiKeyRequest{
+		Name:              "cbdino_pool_dev_abcd1234",
+		Description:       "Created by cbdinocluster",
+		Expiry:            ExpiryNever,
+		OrganizationRoles: []string{OrganizationRoleOwner},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/v4/organizations/org/apikeys", gotPath)
+	assert.Equal(t, "Bearer test-secret", gotAuth)
+	assert.Equal(t, "cbdino_pool_dev_abcd1234", body["name"])
+	assert.Equal(t, "Created by cbdinocluster", body["description"])
+	assert.Equal(t, float64(-1), body["expiry"])
+	assert.Equal(t, []any{"organizationOwner"}, body["organizationRoles"])
+	assert.NotContains(t, body, "allowedCIDRs")
+
+	assert.Equal(t, "key-1", resp.ID)
+	assert.Equal(t, "the-secret", resp.Token)
+}
+
+func TestDeleteApiKey(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	err := client.DeleteApiKey(context.Background(), "org", "key-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, "/v4/organizations/org/apikeys/key-1", gotPath)
+	assert.Equal(t, "Bearer test-secret", gotAuth)
+}
+
+func TestRotateApiKey(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotBody []byte
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+
+		_, _ = w.Write([]byte(`{"secretKey":"key-1","token":"the-new-secret"}`))
+	}))
+
+	resp, err := client.RotateApiKey(context.Background(), "org", "key-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/v4/organizations/org/apikeys/key-1/rotate", gotPath)
+	assert.Equal(t, "Bearer test-secret", gotAuth)
+	// Capella picks the new secret itself when the request carries no body.
+	assert.Empty(t, gotBody)
+
+	assert.Equal(t, "key-1", resp.SecretKey)
+	assert.Equal(t, "the-new-secret", resp.Token)
+}
+
+func TestApiKeyErrorsAreDecoded(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code":1002,"hint":"needs owner","httpStatusCode":403,"message":"access denied"}`))
+	}))
+
+	_, err := client.ListApiKeys(context.Background(), "org")
+	require.Error(t, err)
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.HttpStatusCode)
+	assert.Equal(t, "access denied", apiErr.Message)
+}

--- a/utils/capellav4/client.go
+++ b/utils/capellav4/client.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,7 +31,8 @@ type Client struct {
 	logger     *zap.Logger
 	httpClient *http.Client
 	endpoint   string
-	secretKey  string
+	secretKeys []string
+	nextKey    atomic.Uint64
 }
 
 type ClientOptions struct {
@@ -37,14 +40,21 @@ type ClientOptions struct {
 	HttpClient *http.Client
 	Endpoint   string
 	// The v4 API authenticates with the secret alone. The access key is not sent.
-	SecretKey string
+	// Capella limits requests per key, so a pool of keys raises the budget.
+	SecretKeys []string
 }
 
 func NewClient(opts *ClientOptions) (*Client, error) {
 	if opts == nil {
 		return nil, errors.New("client options must be specified")
 	}
-	if opts.SecretKey == "" {
+	var secretKeys []string
+	for _, secretKey := range opts.SecretKeys {
+		if secretKey = strings.TrimSpace(secretKey); secretKey != "" {
+			secretKeys = append(secretKeys, secretKey)
+		}
+	}
+	if len(secretKeys) == 0 {
 		return nil, errors.New("a capella api secret key is required")
 	}
 
@@ -67,7 +77,7 @@ func NewClient(opts *ClientOptions) (*Client, error) {
 		logger:     logger,
 		httpClient: httpClient,
 		endpoint:   endpoint,
-		secretKey:  opts.SecretKey,
+		secretKeys: secretKeys,
 	}, nil
 }
 
@@ -113,7 +123,12 @@ func isRetryable(err error) bool {
 	}
 }
 
-func (c *Client) doOnce(ctx context.Context, method, path string, body, out any) error {
+func isRateLimit(err error) bool {
+	var apiErr *Error
+	return errors.As(err, &apiErr) && apiErr.HttpStatusCode == http.StatusTooManyRequests
+}
+
+func (c *Client) doOnce(ctx context.Context, secretKey, method, path string, body, out any) error {
 	var bodyRdr io.Reader
 	if body != nil {
 		encoded, err := json.Marshal(body)
@@ -131,7 +146,7 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body, out any)
 	if bodyRdr != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Authorization", "Bearer "+c.secretKey)
+	req.Header.Set("Authorization", "Bearer "+secretKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -179,9 +194,25 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body, out any)
 	return nil
 }
 
+// send tries the request once per key, so a rate limited key costs a key swap
+// rather than a wait.
+func (c *Client) send(ctx context.Context, method, path string, body, out any) error {
+	start := c.nextKey.Add(1)
+
+	var err error
+	for i := range c.secretKeys {
+		secretKey := c.secretKeys[(start+uint64(i))%uint64(len(c.secretKeys))]
+		err = c.doOnce(ctx, secretKey, method, path, body, out)
+		if !isRateLimit(err) {
+			return err
+		}
+	}
+	return err
+}
+
 func (c *Client) doRead(ctx context.Context, method, path string, body, out any) error {
 	for retryNum := 0; ; retryNum++ {
-		err := c.doOnce(ctx, method, path, body, out)
+		err := c.send(ctx, method, path, body, out)
 		if err == nil {
 			return nil
 		}
@@ -212,9 +243,11 @@ func (c *Client) doRead(ctx context.Context, method, path string, body, out any)
 	}
 }
 
-// Writes are never retried to prevent e.g. a repeated create which provisions the resource twice.
+// A write is never repeated, because a second attempt could provision the resource twice.
+// Only a 429 was safe to handle automatically, since the server refused the request before
+// doing any work, and the key sweep in send now covers that.
 func (c *Client) doWrite(ctx context.Context, method, path string, body, out any) error {
-	return c.doOnce(ctx, method, path, body, out)
+	return c.send(ctx, method, path, body, out)
 }
 
 type pageInfo struct {

--- a/utils/capellav4/client.go
+++ b/utils/capellav4/client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,8 +32,10 @@ type Client struct {
 	logger     *zap.Logger
 	httpClient *http.Client
 	endpoint   string
-	secretKeys []string
 	nextKey    atomic.Uint64
+
+	keysLock   sync.Mutex
+	secretKeys []string
 }
 
 type ClientOptions struct {
@@ -81,6 +84,53 @@ func NewClient(opts *ClientOptions) (*Client, error) {
 	}, nil
 }
 
+// AddSecretKey puts a secret at the end of the ring. A request already in
+// flight keeps the ring it started with, the new secret joins the next call.
+func (c *Client) AddSecretKey(secret string) {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return
+	}
+
+	c.keysLock.Lock()
+	defer c.keysLock.Unlock()
+
+	for _, secretKey := range c.secretKeys {
+		if secretKey == secret {
+			return
+		}
+	}
+	c.secretKeys = append(c.secretKeys, secret)
+}
+
+// RemoveSecretKey takes a secret out of the ring, keeping the order of the
+// rest. A key must leave the ring before it is rotated or deleted, otherwise a
+// later call could authorize itself with a secret that no longer works.
+func (c *Client) RemoveSecretKey(secret string) {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return
+	}
+
+	c.keysLock.Lock()
+	defer c.keysLock.Unlock()
+
+	kept := c.secretKeys[:0]
+	for _, secretKey := range c.secretKeys {
+		if secretKey == secret {
+			continue
+		}
+		kept = append(kept, secretKey)
+	}
+	c.secretKeys = kept
+}
+
+func (c *Client) secretKeySnapshot() []string {
+	c.keysLock.Lock()
+	defer c.keysLock.Unlock()
+	return append([]string(nil), c.secretKeys...)
+}
+
 type Error struct {
 	Code           int    `json:"code"`
 	Hint           string `json:"hint"`
@@ -88,6 +138,9 @@ type Error struct {
 	Message        string `json:"message"`
 
 	FullText string `json:"-"`
+
+	retryAfterSecs int
+	hasRetryAfter  bool
 }
 
 var _ error = (*Error)(nil)
@@ -123,9 +176,20 @@ func isRetryable(err error) bool {
 	}
 }
 
-func isRateLimit(err error) bool {
+func IsRateLimit(err error) bool {
 	var apiErr *Error
 	return errors.As(err, &apiErr) && apiErr.HttpStatusCode == http.StatusTooManyRequests
+}
+
+// RetryAfterSeconds reports how long Capella asked the caller to wait. It
+// reports false when the answer carried no usable Retry-After header, so the
+// caller has to pick its own delay.
+func RetryAfterSeconds(err error) (int, bool) {
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		return 0, false
+	}
+	return apiErr.retryAfterSecs, apiErr.hasRetryAfter
 }
 
 func (c *Client) doOnce(ctx context.Context, secretKey, method, path string, body, out any) error {
@@ -166,6 +230,12 @@ func (c *Client) doOnce(ctx context.Context, secretKey, method, path string, bod
 		if apiErr.Message == "" {
 			apiErr.Message = string(respBytes)
 		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if secs, err := strconv.Atoi(resp.Header.Get("Retry-After")); err == nil {
+				apiErr.retryAfterSecs = secs
+				apiErr.hasRetryAfter = true
+			}
+		}
 
 		return apiErr
 	}
@@ -197,13 +267,18 @@ func (c *Client) doOnce(ctx context.Context, secretKey, method, path string, bod
 // send tries the request once per key, so a rate limited key costs a key swap
 // rather than a wait.
 func (c *Client) send(ctx context.Context, method, path string, body, out any) error {
+	secretKeys := c.secretKeySnapshot()
+	if len(secretKeys) == 0 {
+		return errors.New("the capella api key ring is empty, no secret key is left to send with")
+	}
+
 	start := c.nextKey.Add(1)
 
 	var err error
-	for i := range c.secretKeys {
-		secretKey := c.secretKeys[(start+uint64(i))%uint64(len(c.secretKeys))]
+	for i := range secretKeys {
+		secretKey := secretKeys[(start+uint64(i))%uint64(len(secretKeys))]
 		err = c.doOnce(ctx, secretKey, method, path, body, out)
-		if !isRateLimit(err) {
+		if !IsRateLimit(err) {
 			return err
 		}
 	}

--- a/utils/capellav4/client_test.go
+++ b/utils/capellav4/client_test.go
@@ -108,7 +108,7 @@ func TestSendUsesEveryKeyWhenCallersRunConcurrently(t *testing.T) {
 			defer wg.Done()
 			path := fmt.Sprintf("/v4/caller-%d", i)
 			err := client.send(context.Background(), http.MethodGet, path, nil, nil)
-			assert.True(t, isRateLimit(err))
+			assert.True(t, IsRateLimit(err))
 		}()
 	}
 	wg.Wait()
@@ -148,7 +148,7 @@ func TestSendReturnsRateLimitWhenEveryKeyIsLimited(t *testing.T) {
 	err := client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
 	require.Error(t, err)
 
-	assert.True(t, isRateLimit(err))
+	assert.True(t, IsRateLimit(err))
 	assert.Equal(t, int32(2), requests.Load())
 }
 
@@ -464,4 +464,93 @@ func TestUserHasPrivilege(t *testing.T) {
 			assert.Equal(t, tt.wantWrite, tt.user.HasPrivilege(PrivilegeDataWriter))
 		})
 	}
+}
+
+func TestAddAndRemoveSecretKeyChangeTheSweep(t *testing.T) {
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer key-a" {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"clus"}`))
+	}), "key-a")
+
+	err := client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+	assert.True(t, IsRateLimit(err))
+
+	client.AddSecretKey("key-b")
+	require.NoError(t, client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil))
+
+	// A second add of the same secret must not grow the ring.
+	client.AddSecretKey("key-b")
+	client.RemoveSecretKey("key-b")
+	err = client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+	assert.True(t, IsRateLimit(err))
+
+	client.RemoveSecretKey("key-a")
+	err = client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+	assert.False(t, IsRateLimit(err))
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestRateLimitErrorExposesRetryAfter(t *testing.T) {
+	var retryAfter string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if retryAfter != "" {
+			w.Header().Set("Retry-After", retryAfter)
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+	}))
+
+	retryAfter = "7"
+	err := client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+	secs, ok := RetryAfterSeconds(err)
+	assert.True(t, ok)
+	assert.Equal(t, 7, secs)
+
+	retryAfter = ""
+	err = client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+	_, ok = RetryAfterSeconds(err)
+	assert.False(t, ok)
+}
+
+func TestRingStaysUsableWhileItChanges(t *testing.T) {
+	const senders = 4
+	const changers = 2
+	const rounds = 20
+
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"clus"}`))
+	}), "key-0")
+
+	var wg sync.WaitGroup
+	for i := 0; i < senders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for round := 0; round < rounds; round++ {
+				assert.NoError(t, client.send(context.Background(),
+					http.MethodGet, "/v4/whatever", nil, nil))
+			}
+		}()
+	}
+	for i := 0; i < changers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for round := 0; round < rounds; round++ {
+				secret := fmt.Sprintf("key-%d-%d", i, round)
+				client.AddSecretKey(secret)
+				client.RemoveSecretKey(secret)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/utils/capellav4/client_test.go
+++ b/utils/capellav4/client_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,13 +18,18 @@ import (
 
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
+	return newTestClientWithKeys(t, handler, "test-secret")
+}
+
+func newTestClientWithKeys(t *testing.T, handler http.Handler, secretKeys ...string) *Client {
+	t.Helper()
 
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
 	client, err := NewClient(&ClientOptions{
-		Endpoint:  srv.URL,
-		SecretKey: "test-secret",
+		Endpoint:   srv.URL,
+		SecretKeys: secretKeys,
 	})
 	require.NoError(t, err)
 
@@ -33,8 +40,116 @@ func TestNewClientRequiresSecret(t *testing.T) {
 	_, err := NewClient(&ClientOptions{})
 	require.Error(t, err)
 
+	_, err = NewClient(&ClientOptions{SecretKeys: []string{}})
+	require.Error(t, err)
+
+	_, err = NewClient(&ClientOptions{SecretKeys: []string{"", "  "}})
+	require.Error(t, err)
+
 	_, err = NewClient(nil)
 	require.Error(t, err)
+}
+
+func TestSendSwapsKeyOnRateLimit(t *testing.T) {
+	var gotAuth []string
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		if len(gotAuth) < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"clus"}`))
+	}), "key-1", "key-2", "key-3")
+
+	cluster, err := client.GetCluster(context.Background(), "org", "proj", "clus")
+	require.NoError(t, err)
+
+	assert.Equal(t, "clus", cluster.ID)
+	assert.ElementsMatch(t, []string{"Bearer key-1", "Bearer key-2", "Bearer key-3"}, gotAuth)
+}
+
+func TestSendUsesEveryKeyWhenCallersRunConcurrently(t *testing.T) {
+	const concurrency = 8
+	secretKeys := []string{"key-1", "key-2", "key-3", "key-4"}
+
+	var mu sync.Mutex
+	cond := sync.NewCond(&mu)
+	gotAuth := make(map[string][]string)
+	arrived := 0
+	round := 0
+
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth[r.URL.Path] = append(gotAuth[r.URL.Path], r.Header.Get("Authorization"))
+
+		// Hold every caller until all of them arrived, so the attempts interleave
+		// the way concurrent project inspections do.
+		arrived++
+		if arrived == concurrency {
+			arrived = 0
+			round++
+			cond.Broadcast()
+		} else {
+			for myRound := round; round == myRound; {
+				cond.Wait()
+			}
+		}
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+	}), secretKeys...)
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			path := fmt.Sprintf("/v4/caller-%d", i)
+			err := client.send(context.Background(), http.MethodGet, path, nil, nil)
+			assert.True(t, isRateLimit(err))
+		}()
+	}
+	wg.Wait()
+
+	var wantAuth []string
+	for _, secretKey := range secretKeys {
+		wantAuth = append(wantAuth, "Bearer "+secretKey)
+	}
+
+	require.Len(t, gotAuth, concurrency)
+	for path, auths := range gotAuth {
+		assert.ElementsMatch(t, wantAuth, auths, "caller %s did not try every key once", path)
+	}
+}
+
+func TestSendStopsOnNonRateLimitError(t *testing.T) {
+	var requests atomic.Int32
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}), "key-1", "key-2", "key-3")
+
+	err := client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+
+	assert.Equal(t, int32(1), requests.Load())
+}
+
+func TestSendReturnsRateLimitWhenEveryKeyIsLimited(t *testing.T) {
+	var requests atomic.Int32
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+	}), "key-1", "key-2")
+
+	err := client.send(context.Background(), http.MethodGet, "/v4/whatever", nil, nil)
+	require.Error(t, err)
+
+	assert.True(t, isRateLimit(err))
+	assert.Equal(t, int32(2), requests.Load())
 }
 
 func TestClientSendsBearerSecret(t *testing.T) {
@@ -190,6 +305,30 @@ func TestReadDoesNotRetryRateLimit(t *testing.T) {
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, http.StatusTooManyRequests, apiErr.HttpStatusCode)
 	assert.Equal(t, int32(1), requests.Load())
+}
+
+func TestReadFailsFastWhenEveryKeyIsRateLimited(t *testing.T) {
+	secretKeys := []string{"key-1", "key-2", "key-3"}
+
+	var requests atomic.Int32
+	client := newTestClientWithKeys(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"code":1004,"httpStatusCode":429,"message":"rate limit"}`))
+	}), secretKeys...)
+
+	start := time.Now()
+	_, err := client.GetCluster(context.Background(), "org", "proj", "clus")
+	elapsed := time.Since(start)
+	require.Error(t, err)
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusTooManyRequests, apiErr.HttpStatusCode)
+
+	// One attempt per key, then the caller sees the 429 without a retry wait.
+	assert.Equal(t, int32(len(secretKeys)), requests.Load())
+	assert.Less(t, elapsed, 500*time.Millisecond)
 }
 
 func TestWriteIsNeverRetried(t *testing.T) {


### PR DESCRIPTION
## Motivation

Capella allows 100 req/m per API key, and normal CI usage of cbdino rapidly hits that limit.
This PR adds a way for cbdino to manage a pool of API keys which it round-robins on per Capella V4 API call to raise that limit.

## Changes

On `init` when configuring Capella, cbdino will ask for a Capella V4 API key. It then asks for a friendly name to recognise the client who owns they key(s) (defaults to your configured github username).  `cbdino` then asks if you want to create a pool of keys (default 3) which it will name `cbdino_pool_{name}_{uid}`. It will first check if any keys already exist with that prefix remotely but not locally in your `cbdinoconfig`, and if so will offer to rotate them or delete them. 

The v4 client round robins every request over a pool of keys as part of normal usage. Hitting a rate limit tries the next key in the pool until retrying N times (N being the pool size) before failing (instead of retrying following the "retry-after" in the response header which would be mostly 60s anyway).

- `init` rotates pool keys it holds no secret for as the API never returns a secret after creation.
- `init --auto` doesn't calls the Capella API and never creates keys unless asked with a flag, so unattended setups behave as before. 

Managing the pool later:
```bash
cbdinocluster cloud apikeys list
cbdinocluster cloud apikeys rotate
cbdinocluster cloud apikeys remove (optional --dry-run)
```
## Flags for `cbdinocluster init --auto`

- `--capella-create-pool`, creates the keys the pool is missing
- `--capella-pool-name`, the name that identifies this machine's pool, part of every key name
- `--capella-pool-size`, how many keys the pool should hold, default 3
- `--capella-pool-expiry`, days until a created key expires, defaults to 12h